### PR TITLE
add phase model to the CipPlannerView

### DIFF
--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -84,6 +84,10 @@ class Phase(models.Model):
 
         super().save(*args, **kwargs)
 
+    @property
+    def name(self):
+        return f'{self.phase_type} - {self.estimated_bid_quarter} - {self.status}'
+
 
 class ScoreField(models.IntegerField):
     def __init__(self, *args, **kwargs):

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -24,25 +24,28 @@ class CipPlannerView(LoginRequiredMixin, TemplateView):
         context = super().get_context_data(*args, **kwargs)
 
         projects = Project.objects.all()
-        projects = projects.select_related('section_owner', 'category', 'phasefinances', 'projectscore')
+        projects = projects.select_related('section_owner', 'category', 'projectscore')
 
         projects_list = []
         for prj in projects:
-            project = {
-                'pk': prj.id,
-                'name': prj.name,
-                'description': prj.description,
-                'section': prj.section_owner.name,
-                'category': prj.category.name,
-                'total_budget': prj.projectfinances.budget.amount,
-                'total_score': prj.projectscore.total_score,
-                'phase': prj.phase,
-                'zones': list(prj.zones.all().values('name')),
-                'house_districts': list(prj.house_districts.all().values('name')),
-                'senate_districts': list(prj.senate_districts.all().values('name')),
-                'commissioner_districts': list(prj.commissioner_districts.all().values('name'))
-            }
-            projects_list.append(project)
+            phases = Phase.objects.filter(project=prj)
+            for phase in phases:
+                phase_finances = PhaseFinances.objects.get(phase=phase)
+                project = {
+                    'pk': prj.id,
+                    'name': prj.name,
+                    'description': prj.description,
+                    'section': prj.section_owner.name,
+                    'category': prj.category.name,
+                    'total_score': prj.projectscore.total_score,
+                    'phase': phase.name,
+                    'total_budget': phase_finances.budget.amount,
+                    'zones': list(prj.zones.all().values('name')),
+                    'house_districts': list(prj.house_districts.all().values('name')),
+                    'senate_districts': list(prj.senate_districts.all().values('name')),
+                    'commissioner_districts': list(prj.commissioner_districts.all().values('name'))
+                }
+                projects_list.append(project)
 
         context['props'] = {'projects': json.dumps(projects_list, cls=DjangoJSONEncoder)}
         return context


### PR DESCRIPTION
## Overview
Fixes the CIP Planner, which was broken after we added the new `Phase` model. There's no issue for this.

## Demo
![cip-planner-fix](https://user-images.githubusercontent.com/38969506/146801417-034ed2bc-b3c3-4ba1-a831-8e27ef3397be.gif)

## Notes
Is there a better way to deal with the `Project`/`Phase` relationships using the ORM? `select_related` and `prefetch_related` wouldn't work, so I ended up querying it like this code implementation. Seems like that would be inefficient with a ton of unnecessary database queries?

## Testing Instructions
- visit review app: tk
- create project so there's some data to test with
- (it won't have the phase stuff since that form isn't implemented?)
- go to the cip planner and make sure it works
