### PR TITLE
Enable access to the remote GIS database from ephemeral app instances on Heroku

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
 ## Testing Instructions
 
 If you are opening a PR for functionality that requires access to the remote GIS
-database from your review app, don't forget to attach the QuotaGuard static add-on
+database from your review app, don't forget to attach the QuotaGuard Static add-on
 to your review app after it initializes:
 
 ```bash

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,15 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
 
 ## Testing Instructions
 
+If you are opening a PR for functionality that requires access to the remote GIS
+datbase from your review app, don't forget to attach the QuotaGuard static add-on
+to your review app after initializes, like so:
+
+```bash
+# From your local command line
+heroku addons:attach -a ${REVIEW_APP} quotaguardstatic
+```
+
 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,8 +15,8 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
 ## Testing Instructions
 
 If you are opening a PR for functionality that requires access to the remote GIS
-datbase from your review app, don't forget to attach the QuotaGuard static add-on
-to your review app after initializes, like so:
+database from your review app, don't forget to attach the QuotaGuard static add-on
+to your review app after it initializes:
 
 ```bash
 # From your local command line

--- a/.qgtunnel
+++ b/.qgtunnel
@@ -1,0 +1,6 @@
+
+[qgtunnel.CCFP_GIS_Database]
+accept = "127.0.0.1:25060"
+connect = "db-postgresql-nyc1-34623-do-user-1547545-0.db.ondigitalocean.com:25060"
+encrypted = false
+transparent = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,3 +54,8 @@ ENV DJANGO_DEBUG 'False'
 # Build static files into the container
 RUN python manage.py collectstatic --noinput
 RUN python manage.py compress
+
+# Install QGTunnel to enable access to GIS database. The QuotaGuard docs say
+# this step should be run from the root directory of the app:
+# https://quotaguard.github.io/qg-docs/quickstart-socks5
+RUN curl https://s3.amazonaws.com/quotaguard/qgtunnel-latest.tar.gz | tar xz

--- a/app.json
+++ b/app.json
@@ -7,6 +7,9 @@
     },
     "DJANGO_SECRET_KEY": {
       "required": true
+    },
+    "GIS_DATABASE_URL": {
+      "required": true
     }
   },
   "formation": {

--- a/heroku.yml
+++ b/heroku.yml
@@ -9,6 +9,4 @@ release:
     - ./scripts/release.sh
   image: web
 run:
-  web: >-
-    bin/qgtunnel gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application || \
-    gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application
+  web: ./scripts/run-app.sh

--- a/heroku.yml
+++ b/heroku.yml
@@ -9,4 +9,6 @@ release:
     - ./scripts/release.sh
   image: web
 run:
-  web: gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application
+  web: >-
+    bin/qgtunnel gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application || \
+    gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,4 +6,7 @@ set -euo pipefail
 python manage.py collectstatic --noinput
 python manage.py migrate --noinput
 python manage.py createcachetable && python manage.py clear_cache
-python manage.py loaddata asset_dashboard/fixtures/data.json
+
+if [ `psql ${DATABASE_URL} -tAX -c "SELECT COUNT(*) FROM auth_user"` -eq "0" ]; then
+    python manage.py loaddata asset_dashboard/fixtures/data.json
+fi

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # scripts/run-app.sh -- Command to run the app on Heroku
 
-if [[ -n "${QUOTAGUARDSTATIC_URL}" && -n "${QUOTAGUARDSHIELD_URL}" ]];
+if [[ -n "${QUOTAGUARDSTATIC_URL}" ]];
 then
     bin/qgtunnel gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application;
 else

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# scripts/run-app.sh -- Command to run the app on Heroku
+
+if [[ -n "${QUOTAGUARDSTATIC_URL}" && -n "${QUOTAGUARDSHIELD_URL}" ]];
+then
+    bin/qgtunnel gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application;
+else
+    gunicorn -t 180 -w 3 --log-level debug asset_dashboard.wsgi:application;
+fi


### PR DESCRIPTION
## Overview

This PR installs `qgtunnel` and updates `heroku.yml` to initialize a tunnel to the GIS database server when starting the app with `gunicorn`.

It also updates the release script so fixture data is only loaded against an empty database, addressing deployment failures on staging.

Closes #59.

### Demo

From a Heroku shell against the staging app:

```
# N.b., Prefix any command with bin/qgtunnel to establish the tunnel for that process
~ $ bin/qgtunnel python manage.py shell
Python 3.8.12 (default, Dec  3 2021, 01:52:45)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from django.db import connections
>>> connections['fp_postgis'].ensure_connection()
>>> from asset_dashboard.models import NaturePreserves
>>> NaturePreserves.objects.count()
47
```

### Notes

Outside of version control, I provisioned a QuotaGuard Static add-on for the staging app, asked Garret to whitelist the provided IPs as trusted traffic sources for GIS database, then configured the tunnel [following these instructions](https://quotaguard.github.io/qg-docs/quickstart-socks5). The resulting config is committed to version control in this PR to remove our dependency on the QuotaGuard site. I also added the `GIS_DATABASE_URL` to review app config vars in the Heroku UI.

As this approach relies on static IPs being available, it will only work for apps to which we've attached the QuotaGuard Static add-on. By default, this excludes review apps, and if it's possible, I think it's probably a good idea to write the GIS integration such that the app is resilient enough for testing without access to the GIS database.

For scenarios where we _do_ want GIS access for a review app, QuotaGuard Static instances [can be shared between apps](https://devcenter.heroku.com/articles/add-ons#sharing-an-add-on-between-apps), so we can do `heroku:attach -a ${REVIEW_APP} quotaguardstatic` after the app is initialized. I've gone ahead and tested this approach with the review app created by this PR. Worked as expected!

## Testing Instructions

_All testing already done._

* Already tested the staging site, as documented in the demo section. [DONE]
* Confirm a review app is created and can be accessed as normal. [DONE]
* Attach the QG Static add-on to the review app and confirm via the shell that the remote GIS database can be access. [DONE]