### PR TITLE
Fix phase name bug

### DIFF
--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -163,7 +163,7 @@ class Phase(SequencedModel):
         return str(self)
 
     def __str__(self):
-        f'{self.phase_type} - {self.estimated_bid_quarter} - {self.status}'
+        return f'{self.phase_type} - {self.estimated_bid_quarter} - {self.status}'
 
 
 class ScoreField(models.IntegerField):


### PR DESCRIPTION
## Overview
Closes #99.

## Testing Instructions
- Visit the CIP planner: https://ccfp-asset-d-phase-name-ae4b77.herokuapp.com/cip-planner/
  - Test credentials are named `ccfp-asset-dashboard test user` in the shared lastpass folder
- Make sure the page loads without an error and the Phase names show up in the table. 
