### PR TITLE
Improve UI for creating portfolios

### DIFF
--- a/asset_dashboard/static/js/components/BaseTable.js
+++ b/asset_dashboard/static/js/components/BaseTable.js
@@ -41,7 +41,8 @@ const BaseTable = ({ rows = [],  getTrProps = props => props, rowClassNames, sel
         disableSortBy: true,
         Cell: props => <a href={`/projects/${props.value}`}  
                           onClick={e => e.stopPropagation()}
-                          className='btn btn-success btn-sm'>View Project</a>
+                          className='btn btn-outline-dark btn-sm'
+                          target="_blank">View Project</a>
       }
     ], []
   )

--- a/asset_dashboard/static/js/components/PortfolioPicker.js
+++ b/asset_dashboard/static/js/components/PortfolioPicker.js
@@ -2,13 +2,17 @@ import React from 'react'
 
 const PortfolioPicker = ({ portfolios, changePortfolio }) => {
   return (
-    <select
-      className="form-control form-control-lg"
-      onChange={changePortfolio}>
-      {portfolios.map(portfolio => {
-        return <option key={portfolio.id} value={portfolio.id}>{portfolio.name}</option>
-      })}
-    </select>
+    <div className="form-group">
+      <label for="portfolio-select" className="font-weight-bold">Select portfolio</label>
+      <select
+        id="portfolio-select"
+        className="form-control"
+        onChange={changePortfolio}>
+        {portfolios.map(portfolio => {
+          return <option key={portfolio.id} value={portfolio.id}>{portfolio.name}</option>
+        })}
+      </select>
+    </div>
   )
 }
 

--- a/asset_dashboard/static/js/components/PortfolioPicker.js
+++ b/asset_dashboard/static/js/components/PortfolioPicker.js
@@ -3,7 +3,7 @@ import React from 'react'
 const PortfolioPicker = ({ portfolios, changePortfolio }) => {
   return (
     <div className="form-group">
-      <label for="portfolio-select" className="font-weight-bold">Select portfolio</label>
+      <label htmlFor="portfolio-select" className="font-weight-bold">Select portfolio</label>
       <select
         id="portfolio-select"
         className="form-control"

--- a/asset_dashboard/static/js/components/PortfolioPicker.js
+++ b/asset_dashboard/static/js/components/PortfolioPicker.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const PortfolioPicker = ({ portfolios, changePortfolio }) => {
+  return (
+    <select
+      className="form-control form-control-lg"
+      onChange={changePortfolio}>
+      {portfolios.map(portfolio => {
+        return <option key={portfolio.id} value={portfolio.id}>{portfolio.name}</option>
+      })}
+    </select>
+  )
+}
+
+export default PortfolioPicker

--- a/asset_dashboard/static/js/components/PortfolioPicker.js
+++ b/asset_dashboard/static/js/components/PortfolioPicker.js
@@ -3,7 +3,9 @@ import React from 'react'
 const PortfolioPicker = ({ portfolios, changePortfolio }) => {
   return (
     <div className="form-group">
-      <label htmlFor="portfolio-select" className="font-weight-bold">Select portfolio</label>
+      <label htmlFor="portfolio-select">
+        <h5>Select portfolio</h5>
+      </label>
       <select
         id="portfolio-select"
         className="form-control"

--- a/asset_dashboard/static/js/components/PortfolioPicker.js
+++ b/asset_dashboard/static/js/components/PortfolioPicker.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const PortfolioPicker = ({ portfolios, changePortfolio }) => {
+const PortfolioPicker = ({ portfolios, activePortfolio, changePortfolio }) => {
   return (
     <div className="form-group">
       <label htmlFor="portfolio-select">
@@ -9,7 +9,9 @@ const PortfolioPicker = ({ portfolios, changePortfolio }) => {
       <select
         id="portfolio-select"
         className="form-control"
-        onChange={changePortfolio}>
+        onChange={changePortfolio}
+        value={activePortfolio.id ? activePortfolio.id : ''}>
+        <option value="">---</option>
         {portfolios.map(portfolio => {
           return <option key={portfolio.id} value={portfolio.id}>{portfolio.name}</option>
         })}

--- a/asset_dashboard/static/js/components/PortfolioTable.js
+++ b/asset_dashboard/static/js/components/PortfolioTable.js
@@ -29,32 +29,41 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfol
 
   return (
     <div className="mb-5 mt-5">
-      <h3>
-        Portfolio
-      </h3>
       {!edit &&
-        <h4>
+        <h3>
           {portfolio.name}
-          <div className="float-right">
-            <Button
-              variant="success"
-              size="sm"
-              type="button"
-              id="edit-portfolio"
-              className="mr-2"
-              onClick={() => setEdit(true)}>
-              Edit name
-            </Button>
-            <Button
+          <Button
+            variant="outline-success"
+            type="button"
+            id="edit-portfolio"
+            className="ml-2"
+            onClick={() => setEdit(true)}>
+            Edit name
+          </Button>
+          {portfolio.name &&
+            <div className="float-right">
+              <Button
+                variant={portfolio.unsavedChanges ? 'primary' : 'link'}
+                type="button"
+                id="save-portfolio-contents"
+                disabled={portfolio.unsavedChanges ? false : true}
+                className="mr-2 px-3"
+                onClick={savePortfolio}>
+                {portfolio.unsavedChanges
+                  ? 'Save portfolio'
+                  : 'All changes saved'
+                }
+              </Button>
+              <Button
               variant="secondary"
-              size="sm"
-              type="link"
-              id="new-portfolio"
-              onClick={_createNewPortfolio}>
-              New portfolio
-            </Button>
-          </div>
-        </h4>
+                type="link"
+                id="new-portfolio"
+                onClick={_createNewPortfolio}>
+                New portfolio
+              </Button>
+            </div>
+          }
+        </h3>
       }
       {edit &&
         <Form id="portfolio-form" onSubmit={updatePortfolioName}>
@@ -64,26 +73,26 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfol
               defaultValue={portfolio.name ? portfolio.name : ''}
               aria-label="Portfolio name"
               required={true}
-              className="mr-2"
+              className="mr-2 form-control-lg"
               id="portfolio-name"
               name="portfolio-name"
             />
             <Button
               variant="primary"
-              size="sm"
               type="submit"
               id="save-portfolio-name"
               className="mr-3">
               Save name
             </Button>
-            <Button
-              variant="link"
-              size="sm"
-              type="button"
-              id="cancel-edit"
-              onClick={() => setEdit(false)}>
-              Cancel
-            </Button>
+            {portfolio.name &&
+              <Button
+                variant="link"
+                type="button"
+                id="cancel-edit"
+                onClick={() => setEdit(false)}>
+                Cancel
+              </Button>
+            }
           </InputGroup>
         </Form>
       }
@@ -100,22 +109,6 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfol
           )
         }}
       />
-      {portfolio.name &&
-        <div className="d-flex justify-content-center">
-          <Button
-            variant={portfolio.unsavedChanges ? 'primary' : 'link'}
-            type="button"
-            id="save-portfolio-contents"
-            disabled={portfolio.unsavedChanges ? false : true}
-            className="mr-2 px-3"
-            onClick={savePortfolio}>
-            {portfolio.unsavedChanges
-              ? 'Save portfolio'
-              : 'All changes saved'
-            }
-          </Button>
-        </div>
-      }
     </div>
   )
 }

--- a/asset_dashboard/static/js/components/PortfolioTable.js
+++ b/asset_dashboard/static/js/components/PortfolioTable.js
@@ -5,7 +5,7 @@ import Form from 'react-bootstrap/Form'
 import InputGroup from 'react-bootstrap/InputGroup'
 
 const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfolioName, savePortfolio, createNewPortfolio }) => {
-  const [edit, setEdit] = useState(false)
+  const [edit, setEdit] = useState(portfolio.name ? false : true)
 
   const onRowClick = ({ original }) => {
     return {

--- a/asset_dashboard/static/js/components/PortfolioTable.js
+++ b/asset_dashboard/static/js/components/PortfolioTable.js
@@ -1,10 +1,12 @@
-import React from 'react'
+import React, { useState } from 'react'
 import ReactTable from './BaseTable'
 import Button from 'react-bootstrap/Button'
 import Form from 'react-bootstrap/Form'
 import InputGroup from 'react-bootstrap/InputGroup'
 
-const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, onNameChange, savePortfolio }) => {
+const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfolioName, savePortfolio }) => {
+  const [edit, setEdit] = useState(false)
+
   const onRowClick = ({ original }) => {
     return {
       onClick: e => {
@@ -13,30 +15,73 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, onNameChang
     }
   }
 
+  const updatePortfolioName = (e) => {
+    savePortfolioName(e).then(
+      setEdit(false)
+    ).catch(err => {
+      console.error(err)
+    })
+  }
+
   return (
     <div className="mb-5 mt-5">
       <h3>
         Portfolio
       </h3>
-      <Form onSubmit={savePortfolio}>
-        <InputGroup className="mb-3">
-          <Form.Control
-            placeholder="Enter a name for your portfolio..."
-            value={portfolio.name ? portfolio.name : ''}
-            aria-label="Portfolio name"
-            aria-describedby="portfolioName"
-            onChange={onNameChange}
-            required={true}
-          />
-          <Button
-            variant="primary"
-            type="submit"
-            id="save-portfolio"
-            disabled={portfolio.unsavedChanges ? false : true}>
-            Save portfolio
-          </Button>
-        </InputGroup>
-      </Form>
+      {!edit &&
+        <h4>
+          {portfolio.name}
+          <div className="float-right">
+            <Button
+              variant="success"
+              size="sm"
+              type="button"
+              id="edit-portfolio"
+              className="mr-2"
+              onClick={() => setEdit(true)}>
+              Edit name
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              type="button"
+              id="new-portfolio">
+              New portfolio
+            </Button>
+          </div>
+        </h4>
+      }
+      {edit &&
+        <Form id="portfolio-form" onSubmit={updatePortfolioName}>
+          <InputGroup className="mb-3">
+            <Form.Control
+              placeholder="Enter a name for your portfolio..."
+              defaultValue={portfolio.name ? portfolio.name : ''}
+              aria-label="Portfolio name"
+              aria-describedby="portfolioName"
+              required={true}
+              className="mr-2"
+              id="portfolio-name"
+            />
+            <Button
+              variant="primary"
+              size="sm"
+              type="submit"
+              id="save-portfolio-name"
+              className="mr-3">
+              Save name
+            </Button>
+            <Button
+              variant="link"
+              size="sm"
+              type="button"
+              id="cancel-edit"
+              onClick={() => setEdit(false)}>
+              Cancel
+            </Button>
+          </InputGroup>
+        </Form>
+      }
       <ReactTable
         columns={columns}
         rows={portfolio.projects}
@@ -50,6 +95,20 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, onNameChang
           )
         }}
       />
+      <div className="d-flex justify-content-center">
+        <Button
+          variant={portfolio.unsavedChanges ? 'primary' : 'link'}
+          type="button"
+          id="save-portfolio-contents"
+          disabled={portfolio.unsavedChanges ? false : true}
+          className="mr-2 px-3"
+          onClick={savePortfolio}>
+          {portfolio.unsavedChanges
+            ? 'Save portfolio'
+            : 'All changes saved'
+          }
+        </Button>
+      </div>
     </div>
   )
 }

--- a/asset_dashboard/static/js/components/PortfolioTable.js
+++ b/asset_dashboard/static/js/components/PortfolioTable.js
@@ -4,7 +4,7 @@ import Button from 'react-bootstrap/Button'
 import Form from 'react-bootstrap/Form'
 import InputGroup from 'react-bootstrap/InputGroup'
 
-const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfolioName, savePortfolio }) => {
+const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfolioName, savePortfolio, createNewPortfolio }) => {
   const [edit, setEdit] = useState(false)
 
   const onRowClick = ({ original }) => {
@@ -18,9 +18,13 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfol
   const updatePortfolioName = (e) => {
     savePortfolioName(e).then(
       setEdit(false)
-    ).catch(err => {
-      console.error(err)
-    })
+    ).catch(err => console.error(err))
+  }
+
+  const _createNewPortfolio = (e) => {
+    createNewPortfolio(e).then(
+      setEdit(true)
+    ).catch(err => console.error(err))
   }
 
   return (
@@ -44,8 +48,9 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfol
             <Button
               variant="secondary"
               size="sm"
-              type="button"
-              id="new-portfolio">
+              type="link"
+              id="new-portfolio"
+              onClick={_createNewPortfolio}>
               New portfolio
             </Button>
           </div>
@@ -95,20 +100,22 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfol
           )
         }}
       />
-      <div className="d-flex justify-content-center">
-        <Button
-          variant={portfolio.unsavedChanges ? 'primary' : 'link'}
-          type="button"
-          id="save-portfolio-contents"
-          disabled={portfolio.unsavedChanges ? false : true}
-          className="mr-2 px-3"
-          onClick={savePortfolio}>
-          {portfolio.unsavedChanges
-            ? 'Save portfolio'
-            : 'All changes saved'
-          }
-        </Button>
-      </div>
+      {portfolio.name &&
+        <div className="d-flex justify-content-center">
+          <Button
+            variant={portfolio.unsavedChanges ? 'primary' : 'link'}
+            type="button"
+            id="save-portfolio-contents"
+            disabled={portfolio.unsavedChanges ? false : true}
+            className="mr-2 px-3"
+            onClick={savePortfolio}>
+            {portfolio.unsavedChanges
+              ? 'Save portfolio'
+              : 'All changes saved'
+            }
+          </Button>
+        </div>
+      }
     </div>
   )
 }

--- a/asset_dashboard/static/js/components/PortfolioTable.js
+++ b/asset_dashboard/static/js/components/PortfolioTable.js
@@ -63,10 +63,10 @@ const PortfolioTable = ({ portfolio, columns, onRemoveFromPortfolio, savePortfol
               placeholder="Enter a name for your portfolio..."
               defaultValue={portfolio.name ? portfolio.name : ''}
               aria-label="Portfolio name"
-              aria-describedby="portfolioName"
               required={true}
               className="mr-2"
               id="portfolio-name"
+              name="portfolio-name"
             />
             <Button
               variant="primary"

--- a/asset_dashboard/static/js/planner.js
+++ b/asset_dashboard/static/js/planner.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import Button from 'react-bootstrap/Button'
+import { CSVLink } from 'react-csv'
+import Cookies from 'js-cookie'
+
 import ProjectsTable from './components/ProjectsTable'
 import PortfolioTable from './components/PortfolioTable'
 import PortfolioTotals from './components/PortfolioTotals'
 import PortfolioPicker from './components/PortfolioPicker'
 import SearchInput from './components/FilterComponent'
-import { CSVLink } from 'react-csv'
-import Cookies from 'js-cookie'
-
 
 class PortfolioPlanner extends React.Component {
   constructor(props) {

--- a/asset_dashboard/static/js/planner.js
+++ b/asset_dashboard/static/js/planner.js
@@ -226,14 +226,30 @@ class PortfolioPlanner extends React.Component {
       body: JSON.stringify(data)
     }).then(response => {
       return response.json()
-    }).then(data => {
-      this.setState({
+    }).then(portfolioObj => {
+      let state = {
         portfolio: {
           ...this.state.portfolio,
-          id: data.id,
+          id: portfolioObj.id,
           unsavedChanges: false
         }
-      })
+      }
+
+      if (method == 'POST') {
+        // Add newly created portfolio to the portfolio array
+        this.setState({
+          ...state,
+          allPortfolios: [...this.state.allPortfolios, portfolioObj]
+        })
+      } else {
+        // Update existing portfolio in the portfolio array
+        this.setState({
+          ...state,
+          allPortfolios: this.state.allPortfolios.map(portfolio => {
+            return portfolio.id === portfolioObj.id ? portfolioObj : portfolio
+          })
+        })
+      }
     }).catch(error => {
       console.error(error)
     })
@@ -346,6 +362,7 @@ class PortfolioPlanner extends React.Component {
           <div className="col">
             <PortfolioPicker
               portfolios={this.state.allPortfolios}
+              activePortfolio={this.state.portfolio}
               changePortfolio={this.selectPortfolio}
             />
           </div>

--- a/asset_dashboard/static/js/planner.js
+++ b/asset_dashboard/static/js/planner.js
@@ -33,7 +33,7 @@ class PortfolioPlanner extends React.Component {
     this.removeProjectFromPortfolio = this.removeProjectFromPortfolio.bind(this)
     this.searchProjects = this.searchProjects.bind(this)
     this.savePortfolio = this.savePortfolio.bind(this)
-    this.updatePortfolioName = this.updatePortfolioName.bind(this)
+    this.savePortfolioName = this.savePortfolioName.bind(this)
     this.alertUser = this.alertUser.bind(this)
   }
 
@@ -215,12 +215,23 @@ class PortfolioPlanner extends React.Component {
     })
   }
 
-  updatePortfolioName(e) {
-    this.setState({
-      portfolio: {...this.state.portfolio, name: e.target.value}
-    })
+  savePortfolioName(e) {
+    e.persist()
 
-    this.registerChange()
+    return new Promise((resolve, reject) => {
+      const nameInput = document.querySelector('#portfolio-name')
+
+      try {
+        this.setState({
+          portfolio: {...this.state.portfolio, name: nameInput.value}
+        }, () => this.savePortfolio(e))
+      } catch (err) {
+        reject(err)
+        return
+      }
+
+      resolve()
+    })
   }
 
   registerChange(e) {
@@ -251,7 +262,7 @@ class PortfolioPlanner extends React.Component {
                   portfolio={this.state.portfolio}
                   onRemoveFromPortfolio={this.removeProjectFromPortfolio}
                   savePortfolio={this.savePortfolio}
-                  onNameChange={this.updatePortfolioName} />
+                  savePortfolioName={this.savePortfolioName} />
                 <ProjectsTable
                   allProjects={filteredRows}
                   onAddToPortfolio={this.addProjectToPortfolio}

--- a/asset_dashboard/static/js/planner.js
+++ b/asset_dashboard/static/js/planner.js
@@ -242,11 +242,11 @@ class PortfolioPlanner extends React.Component {
     e.persist()
 
     return new Promise((resolve, reject) => {
-      const nameInput = document.querySelector('#portfolio-name')
+      const portfolioName = new FormData(e.target).get('portfolio-name')
 
       try {
         this.setState({
-          portfolio: {...this.state.portfolio, name: nameInput.value}
+          portfolio: {...this.state.portfolio, name: portfolioName}
         }, () => this.savePortfolio(e))
       } catch (err) {
         reject(err)

--- a/asset_dashboard/static/js/planner.js
+++ b/asset_dashboard/static/js/planner.js
@@ -34,6 +34,7 @@ class PortfolioPlanner extends React.Component {
     this.searchProjects = this.searchProjects.bind(this)
     this.savePortfolio = this.savePortfolio.bind(this)
     this.updatePortfolioName = this.updatePortfolioName.bind(this)
+    this.alertUser = this.alertUser.bind(this)
   }
 
   createRegionName(regions) {
@@ -93,6 +94,19 @@ class PortfolioPlanner extends React.Component {
     }
 
     this.setState(state)
+
+    window.addEventListener('beforeunload', this.alertUser)
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.alertUser)
+  }
+
+  alertUser(e) {
+    if (this.state.portfolio.unsavedChanges) {
+      e.preventDefault()
+      e.returnValue = ''
+    }
   }
 
   calculateTotals(portfolio) {

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -29,11 +29,15 @@ class CipPlannerView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
 
-        if portfolio := self.request.user.portfolio_set.order_by('-updated_at').first():
-            portfolio = PortfolioSerializer(portfolio).data
+        portfolios = []
+        selected_portfolio = None
 
-        else:
-            portfolio = None
+        if self.request.user.portfolio_set.count():
+            portfolios = PortfolioSerializer(
+                self.request.user.portfolio_set.order_by('-updated_at'),
+                many=True
+            ).data
+            selected_portfolio = portfolios[0]
 
         phases = Phase.objects.all().select_related('project')
 
@@ -56,8 +60,9 @@ class CipPlannerView(LoginRequiredMixin, TemplateView):
 
         context['props'] = {
             'projects': json.dumps(project_phases, cls=DjangoJSONEncoder),
-            'portfolio': portfolio,
-            'user_id': self.request.user.id,
+            'portfolios': portfolios,
+            'selectedPortfolio': selected_portfolio,
+            'userId': self.request.user.id,
         }
         return context
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "core-js": "^3.20.3",
     "js-cookie": "^3.0.1",
     "react": "^16.13.1",
-    "react-bootstrap": "^2.1.1",
+    "react-bootstrap": "1.6.4",
     "react-csv": "^2.0.3",
     "react-data-table-component": "^6.11.6",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
## Overview

This PR:

- Adds an explicit button for editing portfolio name
- Prompts the user about unsaved changes if they try to navigate away from the current portfolio
- Adds a portfolio picker to switch portfolios

## Notes

TODO: 
- [x] Default to editable name if no portfolios exist
- [x] Update the portfolio picker when a new portfolio is created.

## Testing Instructions

* Navigate to the review app at https://ccfp-asset-d-hcg-portfo-ratya9.herokuapp.com/cip-planner/ and log in using the test user creds in LastPass
* Confirm a portfolio with one phase is rendered by default
* Try removing the phase, then refreshing the page. Confirm you see a dialog confirming you want to navigate away. Also try clicking links to other pages, etc., and confirm the dialog again appears.
* Create a new portfolio. Try adding/removing phases, saving, etc., and confirm the page state reflects your changes (or lack thereof).
* Refresh the page and confirm the last portfolio you edited is active. (Need to add functionality to update the select with a new option when a portfolio is created, will do Monday.)
* Select the other portfolio from the dropdown and confirm it populates the page correctly.
* Try to break the page in other ways I haven't thought of and let me know what doesn't work. :-)