### PR TITLE
Improvements to the asset map UI

### DIFF
--- a/asset_dashboard/serializers.py
+++ b/asset_dashboard/serializers.py
@@ -98,7 +98,16 @@ class LocalAssetReadSerializer(BaseLocalAssetSerializer):
     geom = GeometrySerializerMethodField()
 
 
-class BuildingsSerializer(GeoFeatureModelSerializer):
+class SourceAssetSerializer(GeoFeatureModelSerializer):
+    class Meta:
+        fields = ('source')
+    
+    source = serializers.SerializerMethodField()
+    
+    def get_source(self, obj):
+        return 'search'
+
+class BuildingsSerializer(SourceAssetSerializer):
     class Meta:
         model = Buildings
         fields = ('identifier', 'name', 'geom', 'source')
@@ -107,19 +116,15 @@ class BuildingsSerializer(GeoFeatureModelSerializer):
     identifier = NullableIntegerField(source='fpd_uid', allow_null=True)
     name = serializers.CharField(source='building_name')
     geom = GeometrySerializerMethodField()
-    source = serializers.SerializerMethodField()
 
     def get_geom(self, obj):
         return obj.geom.transform(4326, clone=True)
-    
-    def get_source(self, obj):
-        return 'search'
 
 
-class TrailsSerializer(GeoFeatureModelSerializer):
+class TrailsSerializer(SourceAssetSerializer):
     class Meta:
         model = TrailsInfo
-        fields = ('identifier', 'name', 'geom')
+        fields = ('identifier', 'name', 'geom', 'source')
         geo_field = 'geom'
 
     identifier = serializers.IntegerField(source='trails_id')

--- a/asset_dashboard/serializers.py
+++ b/asset_dashboard/serializers.py
@@ -92,7 +92,7 @@ class BaseLocalAssetSerializer(GeoFeatureModelSerializer):
 
 class LocalAssetWriteSerializer(BaseLocalAssetSerializer):
     geom = GeometryField()
-    
+
     def create(self, validated_data):
         phase = validated_data.pop('phase')
         return LocalAsset.objects.create(phase=phase, **validated_data)

--- a/asset_dashboard/serializers.py
+++ b/asset_dashboard/serializers.py
@@ -101,15 +101,19 @@ class LocalAssetReadSerializer(BaseLocalAssetSerializer):
 class BuildingsSerializer(GeoFeatureModelSerializer):
     class Meta:
         model = Buildings
-        fields = ('identifier', 'name', 'geom')
+        fields = ('identifier', 'name', 'geom', 'source')
         geo_field = 'geom'
 
     identifier = NullableIntegerField(source='fpd_uid', allow_null=True)
     name = serializers.CharField(source='building_name')
     geom = GeometrySerializerMethodField()
+    source = serializers.SerializerMethodField()
 
     def get_geom(self, obj):
         return obj.geom.transform(4326, clone=True)
+    
+    def get_source(self, obj):
+        return 'search'
 
 
 class TrailsSerializer(GeoFeatureModelSerializer):

--- a/asset_dashboard/serializers.py
+++ b/asset_dashboard/serializers.py
@@ -92,6 +92,10 @@ class BaseLocalAssetSerializer(GeoFeatureModelSerializer):
 
 class LocalAssetWriteSerializer(BaseLocalAssetSerializer):
     geom = GeometryField()
+    
+    def create(self, validated_data):
+        phase = validated_data.pop('phase')
+        return LocalAsset.objects.create(phase=phase, **validated_data)
 
 
 class LocalAssetReadSerializer(BaseLocalAssetSerializer):

--- a/asset_dashboard/serializers.py
+++ b/asset_dashboard/serializers.py
@@ -78,7 +78,7 @@ class BaseLocalAssetSerializer(GeoFeatureModelSerializer):
 
     class Meta:
         model = LocalAsset
-        fields = ('geom', 'asset_id', 'asset_type', 'asset_name', 'phase')
+        fields = ('id', 'geom', 'asset_id', 'asset_type', 'asset_name', 'phase')
         geo_field = 'geom'
 
     asset_id = serializers.IntegerField()

--- a/asset_dashboard/serializers.py
+++ b/asset_dashboard/serializers.py
@@ -93,10 +93,6 @@ class BaseLocalAssetSerializer(GeoFeatureModelSerializer):
 class LocalAssetWriteSerializer(BaseLocalAssetSerializer):
     geom = GeometryField()
 
-    def create(self, validated_data):
-        phase = validated_data.pop('phase')
-        return LocalAsset.objects.create(phase=phase, **validated_data)
-
 
 class LocalAssetReadSerializer(BaseLocalAssetSerializer):
     geom = GeometrySerializerMethodField()

--- a/asset_dashboard/static/js/components/map_utils/MapZoom.js
+++ b/asset_dashboard/static/js/components/map_utils/MapZoom.js
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react'
+import { useMap } from 'react-leaflet'
+import zoomToSearchGeometries from './zoomToSearchGeometries'
+
+
+function MapZoom({ searchGeoms }) { 
+  const map = useMap()
+
+  useEffect(() => {
+    const group = new L.featureGroup()
+    zoomToSearchGeometries(map, group)
+  }, [searchGeoms])
+
+  return null
+}
+
+export default MapZoom

--- a/asset_dashboard/static/js/components/map_utils/zoomToSearchGeometries.js
+++ b/asset_dashboard/static/js/components/map_utils/zoomToSearchGeometries.js
@@ -1,0 +1,17 @@
+export default function zoomToSearchGeometries(map, group) {
+    map.eachLayer((layer) => {
+      if (layer.feature?.properties.identifier) {
+        // If "identifier" is in "properties",
+        // then this is a feature from the search.
+        // This is extremely dependent on the search geometries
+        // having this "identifier" key, so beware!
+        // I haven't been able to figure out a better
+        // way of zooming in on the search results.
+        group.addLayer(layer)
+      }
+    })
+  
+    if (Object.keys(group._layers).length > 0) {
+      map.fitBounds(group.getBounds())
+    }
+  }

--- a/asset_dashboard/static/js/components/map_utils/zoomToSearchGeometries.js
+++ b/asset_dashboard/static/js/components/map_utils/zoomToSearchGeometries.js
@@ -1,12 +1,6 @@
 export default function zoomToSearchGeometries(map, group) {
     map.eachLayer((layer) => {
-      if (layer.feature?.properties.identifier) {
-        // If "identifier" is in "properties",
-        // then this is a feature from the search.
-        // This is extremely dependent on the search geometries
-        // having this "identifier" key, so beware!
-        // I haven't been able to figure out a better
-        // way of zooming in on the search results.
+      if (layer.feature?.properties.source === 'search') {
         group.addLayer(layer)
       }
     })

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -3,11 +3,11 @@ import React, { useState, useEffect } from 'react'
 import { GeoJSON } from 'react-leaflet'
 import hash from 'object-hash'
 import Cookies from 'js-cookie'
+import { useSessionstorageState } from 'rooks'
 import BaseMap from './BaseMap'
 import AssetSearchTable from '../tables/AssetSearchTable'
 import ExistingAssetsTable from '../tables/ExistingAssetsTable'
 import MapClipper from '../map_utils/MapClipper'
-import { useSessionstorageState } from 'rooks'
 
 function AssetTypeOptions() {
   // these options could come from the server but hardcoding for now 

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -7,6 +7,7 @@ import BaseMap from './BaseMap'
 import AssetSearchTable from '../tables/AssetSearchTable'
 import ExistingAssetsTable from '../tables/ExistingAssetsTable'
 import MapClipper from '../map_utils/MapClipper'
+import { useSessionstorageState } from 'rooks'
 
 function AssetTypeOptions() {
   // these options could come from the server but hardcoding for now 
@@ -21,11 +22,11 @@ function AssetTypeOptions() {
 }
 
 function AssetsMap(props) {
-  const [searchedGeoms, setSearchedGeoms] = useState()
+  const [searchedGeoms, setSearchedGeoms] = useSessionstorageState('searchGeoms', null)
   const [existingGeoms, setExistingGeoms] = useState()
   const [clippedGeoms, setClippedGeoms] = useState(null)
-  const [searchText, setSearchText] = useState('')
-  const [searchedAssetType, setSearchedAssetType] = useState('buildings')
+  const [searchText, setSearchText] = useSessionstorageState('searchText', '')
+  const [searchedAssetType, setSearchedAssetType] = useSessionstorageState('searchAssetTypes', 'buildings')
   const [isLoading, setIsLoading] = useState(false)
   const [phaseId, setPhaseId] = useState(null)
 

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -8,6 +8,8 @@ import BaseMap from './BaseMap'
 import AssetSearchTable from '../tables/AssetSearchTable'
 import ExistingAssetsTable from '../tables/ExistingAssetsTable'
 import MapClipper from '../map_utils/MapClipper'
+import MapZoom from '../map_utils/MapZoom'
+import zoomToSearchGeometries from '../map_utils/zoomToSearchGeometries'
 
 function AssetTypeOptions() {
   // these options could come from the server but hardcoding for now 
@@ -44,14 +46,18 @@ function AssetsMap(props) {
   function onMapCreated(map) {
     const group = new L.featureGroup()
 
-    map.eachLayer((layer) => {
-      if (layer.feature) {
-        group.addLayer(layer)
+    if (searchGeoms) {
+      zoomToSearchGeometries(map, group)
+    } else {
+      map.eachLayer((layer) => {
+        if (layer.feature) {
+          group.addLayer(layer)
+        }
+      })
+  
+      if (Object.keys(group._layers).length > 0) {
+        map.fitBounds(group.getBounds())
       }
-    })
-
-    if (Object.keys(group._layers).length > 0) {
-      map.fitBounds(group.getBounds())
     }
   }
 
@@ -192,6 +198,7 @@ function AssetsMap(props) {
                       geoJson={searchGeoms}
                       onClipped={onClipped}
                     />
+                    <MapZoom searchGeoms={searchGeoms} />
                 </>
               }
               {existingGeoms && <GeoJSON data={existingGeoms} style={{color: 'green'}}/>}

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -5,6 +5,7 @@ import hash from 'object-hash'
 import Cookies from 'js-cookie'
 import BaseMap from './BaseMap'
 import AssetSearchTable from '../tables/AssetSearchTable'
+import ExistingAssetsTable from '../tables/ExistingAssetsTable'
 import MapClipper from '../map_utils/MapClipper'
 
 function AssetTypeOptions() {
@@ -30,6 +31,7 @@ function AssetsMap(props) {
 
   useEffect(() => {
     if (props?.existing_assets) {
+      console.log(props.existing_assets)
       setExistingGeoms(props.existing_assets)
     }
 
@@ -118,83 +120,92 @@ function AssetsMap(props) {
   }
  
   return (
-    <div className='row'>
-      <div className='col-4'>
-        <div className='row'>
-          <div className='col'>
-            <div className='row m-1'>
-              <label htmlFor='asset-search' className='sr-only'>Search for Assets</label>
-              <input 
-                type='search'
-                onChange={(e) => setSearchText(e.target.value)}
-                value={searchText}
-                className='form-control' 
-                aria-label='Search for assets' 
-                placeholder='Search for assets' />
-            </div>
-            <div className='row m-1'>
-              <select
-                className='form-control col mr-1'
-                value={searchedAssetType}
-                onChange={(e) => setSearchedAssetType(e.target.value)}
-              >
-                <AssetTypeOptions />
-              </select>
-              <button 
-                onClick={() => searchAssets()}
-                className='btn btn-warning'>
-                  Search
-              </button>
+    <>
+      <div className='row'>
+        <div className='col-4'>
+          <div className='row'>
+            <div className='col'>
+              <div className='row m-1'>
+                <label htmlFor='asset-search' className='sr-only'>Search for Assets</label>
+                <input 
+                  type='search'
+                  onChange={(e) => setSearchText(e.target.value)}
+                  value={searchText}
+                  className='form-control' 
+                  aria-label='Search for assets' 
+                  placeholder='Search for assets' />
+              </div>
+              <div className='row m-1'>
+                <select
+                  className='form-control col mr-1'
+                  value={searchedAssetType}
+                  onChange={(e) => setSearchedAssetType(e.target.value)}
+                >
+                  <AssetTypeOptions />
+                </select>
+                <button 
+                  onClick={() => searchAssets()}
+                  className='btn btn-warning'>
+                    Search
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-        <div>
-          {isLoading ? 'Loading...' : null}
-          {searchedGeoms && 
-            <AssetSearchTable
-              rows={searchedGeoms.features}
-            />
-          }
-        </div>
-      </div>
-      <div className='col'>
-        <div className='d-flex justify-content-end m-2'>
-          {clippedGeoms 
-            ?
-              <button 
-                className='btn btn-primary'
-                onClick={() => saveGeometries()}>
-                Save Asset
-              </button>
-            :
-              <p>Use the map toolbar to select an asset.</p>
-          }
-        </div>
-        <div className='map-viewer' aria-label='Asset Selection Map'>
-          <BaseMap
-            center={[41.8781, -87.6298]}
-            zoom={11}
-            whenCreated={onMapCreated}>
+          <div>
+            {isLoading ? 'Loading...' : null}
             {searchedGeoms && 
-              <>
-                <GeoJSON 
-                  data={searchedGeoms} 
-                  // Hash key tells the geojson to re-render 
-                  // when the state changes: https://stackoverflow.com/a/46593710
-                  key={hash(searchedGeoms)} 
-                  style={{color: 'black'}}
-                />
-                  <MapClipper 
-                    geoJson={searchedGeoms}
-                    onClipped={onClipped}
-                  />
-              </>
+              <AssetSearchTable
+                rows={searchedGeoms.features}
+              />
             }
-            {existingGeoms && <GeoJSON data={existingGeoms} style={{color: 'green'}}/>}
-          </BaseMap>
+          </div>
+        </div>
+        <div className='col'>
+          <div className='d-flex justify-content-end m-2'>
+            {clippedGeoms 
+              ?
+                <button 
+                  className='btn btn-primary'
+                  onClick={() => saveGeometries()}>
+                  Save Asset
+                </button>
+              :
+                <p>Use the map toolbar to select an asset.</p>
+            }
+          </div>
+          <div className='map-viewer' aria-label='Asset Selection Map'>
+            <BaseMap
+              center={[41.8781, -87.6298]}
+              zoom={11}
+              whenCreated={onMapCreated}>
+              {searchedGeoms && 
+                <>
+                  <GeoJSON 
+                    data={searchedGeoms} 
+                    // Hash key tells the geojson to re-render 
+                    // when the state changes: https://stackoverflow.com/a/46593710
+                    key={hash(searchedGeoms)} 
+                    style={{color: 'black'}}
+                  />
+                    <MapClipper 
+                      geoJson={searchedGeoms}
+                      onClipped={onClipped}
+                    />
+                </>
+              }
+              {existingGeoms && <GeoJSON data={existingGeoms} style={{color: 'green'}}/>}
+            </BaseMap>
+          </div>
         </div>
       </div>
-    </div>
+      <div>
+        {existingGeoms && 
+          <ExistingAssetsTable
+            rows={existingGeoms.features}
+          />
+        }
+      </div>
+    </>
   )
 }
 

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -186,7 +186,7 @@ function AssetsMap(props) {
                     // Hash key tells the geojson to re-render 
                     // when the state changes: https://stackoverflow.com/a/46593710
                     key={hash(searchedGeoms)} 
-                    style={{color: 'black'}}
+                    style={{color: 'black', dashArray: '5,10', weight: '0.75'}}
                   />
                     <MapClipper 
                       geoJson={searchedGeoms}

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -22,11 +22,11 @@ function AssetTypeOptions() {
 }
 
 function AssetsMap(props) {
-  const [searchedGeoms, setSearchedGeoms] = useSessionstorageState('searchGeoms', null)
+  const [searchGeoms, setSearchGeoms] = useSessionstorageState('searchGeoms', null)
   const [existingGeoms, setExistingGeoms] = useState()
   const [clippedGeoms, setClippedGeoms] = useState(null)
   const [searchText, setSearchText] = useSessionstorageState('searchText', '')
-  const [searchedAssetType, setSearchedAssetType] = useSessionstorageState('searchAssetTypes', 'buildings')
+  const [searchAssetType, setSearchAssetType] = useSessionstorageState('searchAssetTypes', 'buildings')
   const [isLoading, setIsLoading] = useState(false)
   const [phaseId, setPhaseId] = useState(null)
 
@@ -63,7 +63,7 @@ function AssetsMap(props) {
     const data = clippedGeoms['features'].map(feature => {
       return {
         'asset_id': feature['properties']['identifier'],
-        'asset_type': searchedAssetType,
+        'asset_type': searchAssetType,
         'asset_name': feature['properties']['name'],
         'geom': feature['geometry'],
         'phase': phaseId
@@ -98,7 +98,7 @@ function AssetsMap(props) {
 
     const url = `/assets/?` + new URLSearchParams({
       'q': searchText,
-      'asset_type': searchedAssetType
+      'asset_type': searchAssetType
     })
 
     fetch(url, {
@@ -112,7 +112,7 @@ function AssetsMap(props) {
     }).then((response) => response.json())
     .then((data) => {
       setIsLoading(false)
-      setSearchedGeoms(data)
+      setSearchGeoms(data)
     })
     .catch(error => {
       // TODO: show an error message in the UI
@@ -139,8 +139,8 @@ function AssetsMap(props) {
               <div className='row m-1'>
                 <select
                   className='form-control col mr-1'
-                  value={searchedAssetType}
-                  onChange={(e) => setSearchedAssetType(e.target.value)}
+                  value={searchAssetType}
+                  onChange={(e) => setSearchAssetType(e.target.value)}
                 >
                   <AssetTypeOptions />
                 </select>
@@ -154,9 +154,9 @@ function AssetsMap(props) {
           </div>
           <div>
             {isLoading ? 'Loading...' : null}
-            {searchedGeoms && 
+            {searchGeoms && 
               <AssetSearchTable
-                rows={searchedGeoms.features}
+                rows={searchGeoms.features}
               />
             }
           </div>
@@ -179,17 +179,17 @@ function AssetsMap(props) {
               center={[41.8781, -87.6298]}
               zoom={11}
               whenCreated={onMapCreated}>
-              {searchedGeoms && 
+              {searchGeoms && 
                 <>
                   <GeoJSON 
-                    data={searchedGeoms} 
+                    data={searchGeoms} 
                     // Hash key tells the geojson to re-render 
                     // when the state changes: https://stackoverflow.com/a/46593710
-                    key={hash(searchedGeoms)} 
+                    key={hash(searchGeoms)} 
                     style={{color: 'black', dashArray: '5,10', weight: '0.75'}}
                   />
                     <MapClipper 
-                      geoJson={searchedGeoms}
+                      geoJson={searchGeoms}
                       onClipped={onClipped}
                     />
                 </>

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -48,6 +48,7 @@ function AssetsMap(props) {
     if (searchGeoms) {
       zoomToSearchGeometries(map, group)
     } else {
+      // zoom to the existing geometries
       map.eachLayer((layer) => {
         if (layer.feature) {
           group.addLayer(layer)

--- a/asset_dashboard/static/js/components/maps/AssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/AssetsMap.js
@@ -34,7 +34,6 @@ function AssetsMap(props) {
 
   useEffect(() => {
     if (props?.existing_assets) {
-      console.log(props.existing_assets)
       setExistingGeoms(props.existing_assets)
     }
 

--- a/asset_dashboard/static/js/components/table_utils/assetSearchColumns.js
+++ b/asset_dashboard/static/js/components/table_utils/assetSearchColumns.js
@@ -1,12 +1,12 @@
 const assetSearchColumns = [
-    {
-      Header: 'Identifier',
-      accessor: 'properties.identifier'
-    },
-    {
-      Header: 'Name',
-      accessor: 'properties.name', 
-    }
-  ]
+  {
+    Header: 'Identifier',
+    accessor: 'properties.identifier'
+  },
+  {
+    Header: 'Name',
+    accessor: 'properties.name', 
+  }
+]
 
 export default assetSearchColumns

--- a/asset_dashboard/static/js/components/table_utils/existingAssetsColumns.js
+++ b/asset_dashboard/static/js/components/table_utils/existingAssetsColumns.js
@@ -18,13 +18,13 @@ const existingAssetsColumns = (handleDelete) => {
       Header: () => null,
       accessor: 'id',
       disableSortBy: true,
-      Cell: props => (<button onClick={() => handleDelete(props.value)}>Delete</button>)
+      Cell: props => (<button 
+                        className='btn btn-outline-danger' 
+                        onClick={() => handleDelete(props.value)}>
+                          <i className='fas fa-trash'></i> Delete
+                      </button>)
     }
   ]
 }
 
 export default existingAssetsColumns
-
-{/* <a href={`local-assets/${props.value}`}  
-                        onClick={(e) => console.log('click', e.target.value)}
-                        className='btn btn-success btn-sm'>Delete</a> */}

--- a/asset_dashboard/static/js/components/table_utils/existingAssetsColumns.js
+++ b/asset_dashboard/static/js/components/table_utils/existingAssetsColumns.js
@@ -1,0 +1,30 @@
+import React from 'react'
+
+const existingAssetsColumns = (handleDelete) => {
+  return [
+    {
+      Header: 'Identifier',
+      accessor: 'properties.asset_id'
+    },
+    {
+      Header: 'Name',
+      accessor: 'properties.asset_name', 
+    },
+    {
+      Header: 'Type',
+      accessor: 'properties.asset_type'
+    },
+    {
+      Header: () => null,
+      accessor: 'id',
+      disableSortBy: true,
+      Cell: props => (<button onClick={() => handleDelete(props.value)}>Delete</button>)
+    }
+  ]
+}
+
+export default existingAssetsColumns
+
+{/* <a href={`local-assets/${props.value}`}  
+                        onClick={(e) => console.log('click', e.target.value)}
+                        className='btn btn-success btn-sm'>Delete</a> */}

--- a/asset_dashboard/static/js/components/tables/ExistingAssetsTable.js
+++ b/asset_dashboard/static/js/components/tables/ExistingAssetsTable.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Cookies from 'js-cookie'
+import ReactTable from '../BaseTable'
+import existingAssetsColumns from '../table_utils/existingAssetsColumns'
+
+function ExistingAssetsTable({ rows }) {
+  function handleDelete(assetId) {
+    fetch(`/local-assets/${assetId}`, {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-CSRFTOKEN': Cookies.get('csrftoken')
+      },
+      method: 'DELETE',
+      mode: 'same-origin'
+    }).then((response) => {
+      console.log('response', response)
+      if (response.status == 204) {
+        // TODO: this reloads the page but clears the user search...
+        // Need to come up with way to reload by rehydrating the previous state
+        location.reload()
+        // TODO: show success message
+        // https://stackoverflow.com/questions/13256817/django-how-to-show-messages-under-ajax-function
+      }
+    }).catch(error => {
+      // TODO show error message
+      console.error(error)
+    })
+  }
+
+  return (
+    <>
+      <ReactTable
+        rows={rows}
+        columns={React.useMemo(() =>  existingAssetsColumns(handleDelete), [])}
+        pageSizeIncrements={[10, 20, 30]}
+        sizeOfPage={10}
+      />
+    </>
+  )
+}
+
+ExistingAssetsTable.propTypes = {
+  rows: PropTypes.array.isRequired
+}
+
+export default ExistingAssetsTable

--- a/asset_dashboard/templates/asset_dashboard/asset_create_update.html
+++ b/asset_dashboard/templates/asset_dashboard/asset_create_update.html
@@ -16,7 +16,7 @@
       </div>
   </div>
 
-  {% if props.existing_assets %}
+  <!-- {% if props.existing_assets %}
     <table class="table table-hover table-border">
       <thead>
         <tr>
@@ -36,7 +36,7 @@
         {% endfor %}
       </tbody>
     </table>
-  {% endif %}
+  {% endif %} -->
 {% endblock %}
 
 {% block extra_js %}

--- a/asset_dashboard/templates/asset_dashboard/asset_create_update.html
+++ b/asset_dashboard/templates/asset_dashboard/asset_create_update.html
@@ -16,7 +16,7 @@
       </div>
   </div>
 
-  <!-- {% if props.existing_assets %}
+  {% if props.existing_assets %}
     <table class="table table-hover table-border">
       <thead>
         <tr>
@@ -36,7 +36,7 @@
         {% endfor %}
       </tbody>
     </table>
-  {% endif %} -->
+  {% endif %}
 {% endblock %}
 
 {% block extra_js %}

--- a/asset_dashboard/templates/asset_dashboard/asset_create_update.html
+++ b/asset_dashboard/templates/asset_dashboard/asset_create_update.html
@@ -15,28 +15,6 @@
           <i class="pending">Loading map...</i><br><br>
       </div>
   </div>
-
-  <!-- {% if props.existing_assets %}
-    <table class="table table-hover table-border">
-      <thead>
-        <tr>
-          <td><strong>Identifier</strong></td>
-          <td><strong>Name</strong></td>
-          <td><strong>Type</strong></td>
-        </tr>
-      </thead>
-      <tbody>
-        {% for asset in props.existing_assets.features %}
-          <tr>
-            <td>{{ asset.properties.asset_id }}</td>
-            <td>{{ asset.properties.asset_name }}</td>
-            <td>{{ asset.properties.asset_type }}</td>
-            <td>Delete</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  {% endif %} -->
 {% endblock %}
 
 {% block extra_js %}

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -274,9 +274,9 @@ class AssetAddEditView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        
+
         phase = Phase.objects.get(id=self.kwargs['pk'])
-        
+
         context.update({
             'phase': phase,
             'project': Project.objects.filter(phases=phase)[0],

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -274,9 +274,9 @@ class AssetAddEditView(LoginRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
+        
         phase = Phase.objects.get(id=self.kwargs['pk'])
-
+        
         context.update({
             'phase': phase,
             'project': Project.objects.filter(phases=phase)[0],

--- a/package-lock.json
+++ b/package-lock.json
@@ -7225,6 +7225,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -7328,6 +7333,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -7618,6 +7631,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
       "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg=="
+    },
+    "rooks": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/rooks/-/rooks-5.10.0.tgz",
+      "integrity": "sha512-zKO0dOn/GJYn2vdo/vgy9fbQq4xebvJYntaxtJnZRXODhco/nLcNOWnhtwSPwx9X1vFPzdnLypoVrt9MZ+Cmvg==",
+      "requires": {
+        "lodash.debounce": "^4.0.8",
+        "raf": "^3.4.1"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-leaflet": "^3.2.2",
     "react-select": "^3.2.0",
     "react-table": "^7.6.2",
+    "rooks": "^5.10.0",
     "sass": "^1.30.0",
     "styled-components": "^5.2.1",
     "turf-clip": "0.0.1"


### PR DESCRIPTION
## Overview
For issues:
- #109 
- #108
  - i'm importing [the rooks npm library](https://www.npmjs.com/package/rooks) to use a `useSessionStorage` hook for this. i tried to roll my own (real quick) based on an internet example but it was buggy. let me know if we need to use another library.
- #107 
  - it started to get a bit complicated to parse through the geometries and filter out the intersections with turf js (based on [our comments here](https://github.com/fpdcc/ccfp-asset-dashboard/pull/106#issuecomment-1021648455)), so instead i styled the search geometries to have a dashed line and the existing geometries to have a solid line. let me know if that looks awkward or you have any suggestions to tweak the styling.
  - note that this was largely an issue with trails (of geometry type `LineString`)
- #112 
  - i made a `MapZoom` component that uses [the react-leaflet `useMap` hook](https://react-leaflet.js.org/docs/api-map/#usemap). the component zooms to the search geometries if there are any. if there aren't but there are existing geometries, then it will zoom to those geometries.
- renamed some state objects to present tense

### Notes
Remaining UI improvements not in this PR:
- #95
  - i'm still figuring out how to parse out the different types of geometries and leverage turf js. unfortunately, [the turf intersection](https://turfjs.org/docs/#intersect) only accepts polygons/multipolygons and not feature collections (which are the geometry types when we need to use turf). this is requires a bit heavier lifting that i haven't ironed out and could use more scrutiny in a standalone pr.
- #114
  - to do

## Testing Instructions
- visit review app: https://ccfp-asset-d-existing-a-qfqdlr.herokuapp.com
- login with lastpass "ccfp-asset-dashboard test user" credentials
- #109 
 - test the delete button and make sure it deletes your assets from the map from the table
- #108
  - search for assets and then reload by refreshing the page. you can also save an asset or delete one, and your search should persist after the page reloads.
- #107 
  - search for some trails and save a portion trails. when the map reloads (it should've persisted the search!), you should be able to distinguish between the trails you saved and the trails from the search.
- #112 
  - all of the searching in your tests should zoom so that the map fits the bounds of your search geometries. 
  - to test that it zooms to existing geometries on a fresh page load, open the web page in a new tab, since the search geometries are stored in session storage.