### PR TITLE
Improve default behavior for selecting assets

### DIFF
--- a/asset_dashboard/static/js/components/map_utils/MapClipper.js
+++ b/asset_dashboard/static/js/components/map_utils/MapClipper.js
@@ -56,7 +56,8 @@ export default function MapClipper({ geoJson, onClipped }) {
   }
 
   /* Separate the geometry types. We need the LineStrings to clip, 
-    and separately all of the other geometry types to see if they intersect. 
+    and separately all of the other geometry types to see if they 
+    intersect with the drawnGeometries. 
     A LineString would be a trail that can be clipped.
     The remaining types would be like a building or structure, etc
     that should be treated as an entire entity and not clipped. */
@@ -103,9 +104,9 @@ export default function MapClipper({ geoJson, onClipped }) {
   }
 
   function clipGeometries(geometries) {
-    const bounds = turf.featureCollection(Object.values(geometries))
-
     const [lineStringFeatureCollection, allOtherTypesFeatureCollection] = separateGeometryTypes()
+
+    const bounds = turf.featureCollection(Object.values(geometries))
 
     const intersectingFeatures = getIntersectingFeatures(bounds, allOtherTypesFeatureCollection)
 


### PR DESCRIPTION
## Overview
For issue #95.

The code clips the asset geometry if the drawn geometry intersects with a `LineString`/`MultiLineString` (aka a trail). It selects the entire asset's geometry if it's not a `LineString`/`MultiLineString`, like if it's a polygon (aka a building). Previously the code would clip any and all assets, which doesn't make sense because they wouldn't be selecting half of a building. This code prevents a user from selecting half of a building.

### Notes
I'm doing some slicing/dicing with turf js functions. This is the best I could find with the available library functions, but if anybody is more knowledgeable about turf, please don't hesitate to point out approach I might've overlooked. Also, let me know if there's a better way to do this in code...it's not the most efficient because we're looping through features more than once. The turf-clip function is looping through like we are, so I took that as inspiration.

## Testing Instructions
- review app: https://ccfp-asset-d-asset-ui-d-efdwtg.herokuapp.com
- login in lastpass: "ccfp-asset-dashboard test user"
- Select and save a portion of  a trail and make sure it re-renders the portion you selected.
- Select and save half of a building and make sure it re-renders with the entire building.
- Try any geometry types that might be edge cases I'm missing
