### PR TITLE
Improve data export + change year form input + add delete buttons and views

### DIFF
--- a/asset_dashboard/forms.py
+++ b/asset_dashboard/forms.py
@@ -68,10 +68,10 @@ class ProjectCategoryForm(StyledFormMixin, ModelForm):
 class FundingStreamForm(StyledFormMixin, ModelForm):
     SECURED_CHOICES = ((True, 'Yes',), (False, 'No',))
     funding_secured = ChoiceField(choices=SECURED_CHOICES)
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
         year_field = self.fields['year']
         year_field.widget.attrs['min'] = datetime.now().year + 1
 
@@ -99,7 +99,7 @@ class PhaseForm(StyledFormMixin, ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
         year_field = self.fields['year']
         year_field.widget.attrs['min'] = datetime.now().year + 1
 

--- a/asset_dashboard/forms.py
+++ b/asset_dashboard/forms.py
@@ -65,16 +65,6 @@ class ProjectCategoryForm(StyledFormMixin, ModelForm):
         ]
 
 
-def get_year_choices(beginning, end):
-    valid_years = []
-
-    for year in range(beginning, end):
-        choice = (str(year), year)
-        valid_years.append(choice)
-
-    return valid_years
-
-
 class FundingStreamForm(StyledFormMixin, ModelForm):
     SECURED_CHOICES = ((True, 'Yes',), (False, 'No',))
     funding_secured = ChoiceField(choices=SECURED_CHOICES)

--- a/asset_dashboard/forms.py
+++ b/asset_dashboard/forms.py
@@ -78,10 +78,12 @@ def get_year_choices(beginning, end):
 class FundingStreamForm(StyledFormMixin, ModelForm):
     SECURED_CHOICES = ((True, 'Yes',), (False, 'No',))
     funding_secured = ChoiceField(choices=SECURED_CHOICES)
-
-    year = ChoiceField(
-        choices=get_year_choices(datetime.now().year, datetime.now().year+5)
-    )
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        year_field = self.fields['year']
+        year_field.widget.attrs['min'] = datetime.now().year + 1
 
     class Meta:
         model = FundingStream
@@ -107,11 +109,10 @@ class PhaseForm(StyledFormMixin, ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        
+        year_field = self.fields['year']
+        year_field.widget.attrs['min'] = datetime.now().year + 1
 
         for field_name, field in self.fields.items():
             if field_name != 'actual_cost':
                 field.widget.attrs['required'] = True
-
-    year = ChoiceField(
-        choices=get_year_choices(datetime.now().year, datetime.now().year+5)
-    )

--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -352,6 +352,9 @@ class FundingStream(models.Model):
     funding_secured = models.BooleanField(default=False)
     source_type = models.TextField(choices=SOURCE_TYPE_CHOICES, default='capital_improvement_fund')
 
+    def __str__(self):
+        return f'{self.budget} - {self.source_type} - {self.year}'
+
     class Meta:
         verbose_name_plural = 'Phase Funding Stream'
 

--- a/asset_dashboard/static/js/PortfolioPlanner.js
+++ b/asset_dashboard/static/js/PortfolioPlanner.js
@@ -49,7 +49,6 @@ class PortfolioPlanner extends React.Component {
     this.changeSection = this.changeSection.bind(this)
     this.filterSection = this.filterSection.bind(this)
     this.makeExportData = this.makeExportData.bind(this)
-    // this.getCostByZone = this.getCostByZone.bind(this)
   }
 
   componentDidMount() {

--- a/asset_dashboard/static/js/PortfolioPlanner.js
+++ b/asset_dashboard/static/js/PortfolioPlanner.js
@@ -48,6 +48,8 @@ class PortfolioPlanner extends React.Component {
     this.confirmDestroy = this.confirmDestroy.bind(this)
     this.changeSection = this.changeSection.bind(this)
     this.filterSection = this.filterSection.bind(this)
+    this.makeExportData = this.makeExportData.bind(this)
+    // this.getCostByZone = this.getCostByZone.bind(this)
   }
 
   componentDidMount() {
@@ -405,11 +407,6 @@ class PortfolioPlanner extends React.Component {
       portfolio: {...state.portfolio, unsavedChanges: true}
     }))
   }
-
-  getDate() {
-    const date = new Date(new Date().toString().split('GMT')[0]+' UTC').toISOString().split('T')[0]
-    return date
-  }
   
   changeSection(e) {
     const newSection = e.target.value
@@ -441,6 +438,69 @@ class PortfolioPlanner extends React.Component {
   
   filterPortfolio(projects) {
     return projects.filter(this.filterSection)
+  }
+  
+  getExportFileName() {
+    const date = new Date(new Date().toString().split('GMT')[0]+' UTC').toISOString().split('T')[0]
+    const portfolioName = this.state.portfolio.name.replace(' ', '-')
+    return `${portfolioName}-${date}.csv`
+  }
+  
+  makeExportData() {
+    let rows = []
+    
+    this.state.portfolio.projects.forEach(project => {
+      const costByZone = this.getCostByZone(project)
+
+      let row = {
+        ...project,
+        ...costByZone,
+        'zones': project.zones.map(zone => zone.name).join('; '),
+        'house_districts': project.house_districts.map(dist => dist.name).join('; '),
+        'senate_districts': project.senate_districts.map(dist => dist.name).join('; '),
+        'commissioner_districts': project.commissioner_districts.map(dist => dist.name).join('; '),
+      }
+
+      // don't want this key since we parsed the cost_by_zone into their own columns
+      delete row['cost_by_zone']
+
+      if (project.funding_streams.length > 0) {
+        // If there are funding streams, then treat that each 
+        // funding stream instance as an individual row.
+        
+        project.funding_streams.forEach(funding => {
+          row = {
+            ...row,
+            'funding_amount': funding['budget'],
+            'funding_source': funding['source_type'],
+            'funding_year': funding['year']
+          }
+          
+          // remove funding_streams key from the row since the spread operator 
+          // adds it but we don't need it after parsing the funding out.
+          delete row.funding_streams
+
+          rows.push(row)
+        })
+      } else {
+        rows.push(row)
+      }
+    })
+    
+    return rows
+  }
+  
+  getCostByZone(project) {
+    let costByZone = {}
+    
+    Object.entries(project['cost_by_zone']).forEach(([zone, cost]) => {
+      costByZone = {
+        ...costByZone,
+        [`cost_by_${zone.toLowerCase()}_zone`]: Math.round(cost)
+      }
+    })
+    
+    return costByZone
   }
 
   render() {
@@ -489,8 +549,8 @@ class PortfolioPlanner extends React.Component {
             { this.state.portfolio.projects.length > 0
              ? <div className="d-flex justify-content-center mt-3">
                   <CSVLink
-                    data={this.state.portfolio.projects}
-                    filename={`CIP-${this.getDate()}`}
+                    data={this.makeExportData()}
+                    filename={this.getExportFileName()}
                     className='btn btn-info mx-auto'
                     >
                       Export as CSV

--- a/asset_dashboard/templates/asset_dashboard/fundingstream_confirm_delete.html
+++ b/asset_dashboard/templates/asset_dashboard/fundingstream_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends 'asset_dashboard/base.html' %}
+{% load static %}
+{% load static widget_tweaks i18n %}
+
+{% block title %}Delete Funding{% endblock %}
+
+{% block body %}
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-5 bg-white p-3 border rounded shadow-sm">
+                <h2 class="text-center">Delete Funding</h2>
+                <form method="POST">{% csrf_token %}
+                  <p class="text-center">Are you sure you want to delete <br> <strong>{{ object }}</strong> <br> funding from <strong>{{ object.phase }}</strong> phase?</p>
+                  {{ form }}
+
+                  <div class="text-center m-2">
+                    <input type="submit" value="Confirm" class="btn btn-danger">
+                  </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    
+{% endblock %}

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -123,12 +123,16 @@
 </div>
 
 <script type="text/javascript">
+  console.log('loading')
   const status = document.getElementById('id_status').value
   const actualCost = document.getElementById('actualCost')
 
   if (status !== 'complete') {
-    console.log("does not equal completed")
     actualCost.style.display = 'none'
+  } else {
+    <!-- if they're trying to update the phase actual cost once it's "complete", then turn of the year validation. -->
+        console.log("go")
+    document.getElementById('id_year').removeAttribute('min')
   }
 </script>
 {% endblock %}
@@ -136,11 +140,14 @@
 {% block extra_js %}
   {{ block.super }}
   {% load compress %}
+
   {{ props|json_script:"props" }}
   <script type="text/javascript">
+    console.log('get element by id')
     window.props = JSON.parse(document.getElementById('props').textContent)
     window.reactMount = document.getElementById('map')
   </script>
+  
   {% compress js %}
     <script type="text/jsx" src="{% static 'js/components/maps/ListAssetsMap.js' %}"></script>
   {% endcompress %}

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -126,7 +126,6 @@
 </div>
 
 <script type="text/javascript">
-  console.log('loading')
   const status = document.getElementById('id_status').value
   const actualCost = document.getElementById('actualCost')
 
@@ -134,7 +133,6 @@
     actualCost.style.display = 'none'
   } else {
     <!-- if they're trying to update the phase actual cost once it's "complete", then turn of the year validation. -->
-        console.log("go")
     document.getElementById('id_year').removeAttribute('min')
   }
 </script>

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -68,6 +68,8 @@
             <th>Funds</th>
             <th>Source</th>
             <th>Secured</th>
+            <th></th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -78,6 +80,7 @@
             <td>{{ funding.get_source_type_display }}</td>
             <td>{{ funding.funding_secured }}</td>
             <td><a href="{% url 'update-funding' pk=funding.id %}" class="text-info lead">Edit</a></td>
+            <td style="width: 12%;"><a href="{% url 'delete-funding' pk=phase.id %}" class='btn btn-sm btn-outline-danger'><i class='fas fa-trash'></i> Delete</a>
           </tr>
           {% endfor %}
         </tbody>
@@ -140,14 +143,11 @@
 {% block extra_js %}
   {{ block.super }}
   {% load compress %}
-
   {{ props|json_script:"props" }}
   <script type="text/javascript">
-    console.log('get element by id')
     window.props = JSON.parse(document.getElementById('props').textContent)
     window.reactMount = document.getElementById('map')
   </script>
-  
   {% compress js %}
     <script type="text/jsx" src="{% static 'js/components/maps/ListAssetsMap.js' %}"></script>
   {% endcompress %}

--- a/asset_dashboard/templates/asset_dashboard/partials/phase_table.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/phase_table.html
@@ -10,6 +10,7 @@
           <th>Total Budget</th>
           <th>Bid Quarter</th>
           <th></th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -20,6 +21,7 @@
             <td>${{ phase.total_budget|floatformat:2|intcomma }}</td>
             <td>{{ phase.estimated_bid_quarter }}</td>
             <td><a href="{% url 'edit-phase' pk=phase.id %}" class="text-info lead">Edit</a></td>
+            <td style="width: 10%;"><a href="{% url 'delete-phase' pk=phase.id %}" class='btn btn-outline-danger'><i class='fas fa-trash'></i> Delete</a>
           </tr>
         {% endfor %}
       </tbody>

--- a/asset_dashboard/templates/asset_dashboard/phase_confirm_delete.html
+++ b/asset_dashboard/templates/asset_dashboard/phase_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends 'asset_dashboard/base.html' %}
+{% load static %}
+{% load static widget_tweaks i18n %}
+
+{% block title %}Delete Phase{% endblock %}
+
+{% block body %}
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-5 bg-white p-3 border rounded shadow-sm">
+                <h2 class="text-center">Delete Phase</h2>
+                <form method="POST">{% csrf_token %}
+                  <p class="text-center">Are you sure you want to delete <strong>{{ object }}</strong> phase from <strong>{{ object.project }}</strong> project?</p>
+                  {{ form }}
+
+                  <div class="text-center m-2">
+                    <input type="submit" value="Confirm" class="btn btn-danger">
+                  </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    
+{% endblock %}

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -24,7 +24,8 @@ from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreate
                                     ProjectUpdateView, ProjectListJson, \
                                     ProjectsByDistrictListView, ProjectsByDistrictListJson, \
                                     PhaseCreateView, PhaseUpdateView, \
-                                    AssetAddEditView, FundingStreamCreateView, FundingStreamUpdateView
+                                    AssetAddEditView, FundingStreamCreateView, FundingStreamUpdateView, \
+                                    PhaseDeleteView, FundingStreamDeleteView
 
 
 # Routers provide an easy way of automatically determining the URL conf.
@@ -44,8 +45,10 @@ urlpatterns = [
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
     path('projects/<int:pk>/phases/create/', PhaseCreateView.as_view(), name='create-phase'),
     path('projects/phases/edit/<int:pk>/', PhaseUpdateView.as_view(), name='edit-phase'),
+    path('projects/phases/delete/<int:pk>/', PhaseDeleteView.as_view(), name='delete-phase'),
     path('projects/phases/<int:pk>/funding/create/', FundingStreamCreateView.as_view(), name='create-funding'),
     path('projects/phases/<int:pk>/funding/update/', FundingStreamUpdateView.as_view(), name='update-funding'),
+    path('projects/phases/<int:pk>/funding/delete', FundingStreamDeleteView.as_view(), name='delete-funding'),
     path('projects/phases/edit/<int:pk>/assets/', AssetAddEditView.as_view(), name='create-update-assets'),
     path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-district'),
     path('projects/districts/json/', ProjectsByDistrictListJson.as_view(), name='projects-district-json'),

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.html import escape
-from django.views.generic import TemplateView, ListView, CreateView, UpdateView
+from django.views.generic import TemplateView, ListView, CreateView, UpdateView, DeleteView
 
 from django_datatables_view.base_datatable_view import BaseDatatableView
 
@@ -254,6 +254,14 @@ class PhaseUpdateView(LoginRequiredMixin, UpdateView):
             return super().form_invalid(form)
 
 
+class PhaseDeleteView(LoginRequiredMixin, DeleteView):
+    model = Phase
+
+    def get_success_url(self):
+        context = self.get_context_data()
+        messages.success(self.request, 'Phase successfully deleted.')
+        return reverse('project-detail', kwargs={'pk': context['phase'].project.id})
+
 class FundingStreamCreateView(LoginRequiredMixin, CreateView):
     template_name = 'asset_dashboard/partials/forms/create_update_funding_stream_form.html'
     model = FundingStream
@@ -307,6 +315,15 @@ class FundingStreamUpdateView(LoginRequiredMixin, UpdateView):
         context = self.get_context_data()
         messages.success(self.request, 'Funding Stream successfully updated.')
         return reverse('edit-phase', kwargs={'pk': context['phase'].id})
+
+
+class FundingStreamDeleteView(LoginRequiredMixin, DeleteView):
+    model = FundingStream
+
+    def get_success_url(self):
+        context = self.get_context_data()
+        messages.success(self.request, 'Funding Stream successfully deleted.')
+        return reverse('edit-phase', kwargs={'pk': context['fundingstream'].phase_set.get().id})
 
 
 class AssetAddEditView(LoginRequiredMixin, TemplateView):

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -262,6 +262,7 @@ class PhaseDeleteView(LoginRequiredMixin, DeleteView):
         messages.success(self.request, 'Phase successfully deleted.')
         return reverse('project-detail', kwargs={'pk': context['phase'].project.id})
 
+
 class FundingStreamCreateView(LoginRequiredMixin, CreateView):
     template_name = 'asset_dashboard/partials/forms/create_update_funding_stream_form.html'
     model = FundingStream


### PR DESCRIPTION
## Overview
For issues:
- #173 
- #172 
- #168 
- #169

Specifically:
- adds logic in the portfolio planner code to export the cip planner data where the funding stream is the basis for each unique row ([based on discussion here](https://github.com/fpdcc/ccfp-asset-dashboard/issues/166#issuecomment-1097978517))
- changes the phase and funding stream form to have a text input with a minimum year validation
  - the minimum year validation is removed via javascript whenever it's a "completed" project because presumably that will be on or after the completed year, and therefore invalid and not able to save
- adds delete views for phase and funding stream

## Testing Instructions

still no heroku review apps :/

- fetch this `feature/remaining-work` branch
- use the cip planner. create and then export a plan. make sure the data is right.
- test the year input for phase and funding stream
- test the delete buttons for phase (accessible in the project detail page) and funding stream
