### PR TITLE
fix search and cleanup console log

### DIFF
--- a/asset_dashboard/static/js/PortfolioPlanner.js
+++ b/asset_dashboard/static/js/PortfolioPlanner.js
@@ -431,7 +431,7 @@ class PortfolioPlanner extends React.Component {
   
   filterRemainingProjects(projects) {
     return projects.filter(project => {
-      return this.within(project.description, this.state.filterText)
+      return this.within(project.name, this.state.filterText)
     }).filter(this.filterSection)
   }
   

--- a/asset_dashboard/static/js/components/SectionPicker.js
+++ b/asset_dashboard/static/js/components/SectionPicker.js
@@ -13,7 +13,6 @@ const SectionPicker = ({ sections, activeSection, changeSection }) => {
         value={activeSection ? activeSection : ''}>
         <option value="">All Sections</option>
         {sections.map(section => {
-          console.log('section', section)
           return <option key={section} value={section}>{section}</option>
         })}
       </select>


### PR DESCRIPTION
## Overview

Closes:
- #192

### Notes
Changed the search field from `project.description` to `project.name`.

## Testing Instructions
- see slack channel with test credentials
- visit cip planner: https://ccfp-asset-d-fix-cip-se-5vbhxg.herokuapp.com/cip-planner/
- search the projects table (the bottom one). search by project name and make sure it works.
