### PR TITLE
Fix score weight total

### DIFF
--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -340,10 +340,12 @@ class ProjectScore(models.Model):
         # this tuple unpacking will throw an error if that's not so
         score_weights, = ScoreWeights.objects.all()
         total_score = 0
+        weights_sum = 0
 
         for field in score_fields:
             score_field_value = field.value_from_object(self)
             weight_field_value = field.value_from_object(score_weights)
+            weights_sum += weight_field_value
 
             # return a total of 0 if any of the fields are missing a score
             if score_field_value is None:
@@ -352,7 +354,7 @@ class ProjectScore(models.Model):
 
             total_score += score_field_value * weight_field_value
 
-        return total_score
+        return total_score / weights_sum
 
     @receiver([post_save, post_delete], sender='asset_dashboard.LocalAsset')
     def save_project_scores(sender, instance, **kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,7 +38,7 @@ def test_project_score_total_method(project, score_weights):
         score_field_value = getattr(project_score_instance, score_field_name)
         total_score += score_field_value * weight_field_value
 
-    assert project_score_instance.total_score == total_score / weights_sum
+    assert int(project_score_instance.total_score) == int(total_score / weights_sum)
 
     # test that an error will raise if there is no score weight
     with pytest.raises(ValueError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,7 +38,7 @@ def test_project_score_total_method(project, score_weights):
         score_field_value = getattr(project_score_instance, score_field_name)
         total_score += score_field_value * weight_field_value
 
-    assert int(project_score_instance.total_score) == int(total_score / weights_sum)
+    assert pytest.approx(project_score_instance.total_score) == total_score / weights_sum
 
     # test that an error will raise if there is no score weight
     with pytest.raises(ValueError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -30,12 +30,15 @@ def test_project_score_total_method(project, score_weights):
 
     # calculate the score "by hand" (within this test)
     total_score = 0
+    weights_sum = 0
     for index, score_field_name in enumerate(updated_scores):
         weight_field_value = getattr(score_weights, score_field_name)
+        weights_sum += weight_field_value
+        
         score_field_value = getattr(project_score_instance, score_field_name)
         total_score += score_field_value * weight_field_value
 
-    assert project_score_instance.total_score == total_score
+    assert project_score_instance.total_score == total_score / weights_sum
 
     # test that an error will raise if there is no score weight
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Overview

- Closes: #202

### Notes

To fix this, we're dividing the total by the sum of the score weights.

## Testing Instructions
- visit review app: https://ccfp-asset-d-fix-score--lhc8v8.herokuapp.com/
- see some project detail pages
- confirm the weight score is less than or equal to 5
