### PR TITLE
set score_field_value as 0 instead of returning 0 as the total score

### DIFF
--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -349,7 +349,7 @@ class ProjectScore(models.Model):
             total_score += score_field_value * weight_field_value
 
         return total_score / weights_sum
-    
+
     @receiver([post_save], sender='asset_dashboard.Project')
     def update_countywide_score(sender, instance, **kwargs):
         if instance.countywide:

--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -346,7 +346,7 @@ class ProjectScore(models.Model):
             score_field_value = field.value_from_object(self)
             weight_field_value = field.value_from_object(score_weights)
             weights_sum += weight_field_value
-            
+
             # return a total of 0 if any of the fields are missing a score
             if score_field_value is None:
                 total_score = 0

--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -347,10 +347,8 @@ class ProjectScore(models.Model):
             weight_field_value = field.value_from_object(score_weights)
             weights_sum += weight_field_value
 
-            # return a total of 0 if any of the fields are missing a score
             if score_field_value is None:
-                total_score = 0
-                return total_score
+                score_field_value = 0
 
             total_score += score_field_value * weight_field_value
 

--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -346,13 +346,17 @@ class ProjectScore(models.Model):
             score_field_value = field.value_from_object(self)
             weight_field_value = field.value_from_object(score_weights)
             weights_sum += weight_field_value
-
-            if score_field_value is None:
-                score_field_value = 0
-
             total_score += score_field_value * weight_field_value
 
         return total_score / weights_sum
+    
+    @receiver([post_save], sender='asset_dashboard.Project')
+    def update_countywide_score(sender, instance, **kwargs):
+        if instance.countywide:
+            score = ProjectScore.objects.get(project=instance)
+            score.geographic_distance_score = 5
+            score.social_equity_score = 5
+            score.save()
 
     @receiver([post_save, post_delete], sender='asset_dashboard.LocalAsset')
     def save_project_scores(sender, instance, **kwargs):

--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -346,6 +346,12 @@ class ProjectScore(models.Model):
             score_field_value = field.value_from_object(self)
             weight_field_value = field.value_from_object(score_weights)
             weights_sum += weight_field_value
+            
+            # return a total of 0 if any of the fields are missing a score
+            if score_field_value is None:
+                total_score = 0
+                return total_score
+
             total_score += score_field_value * weight_field_value
 
         return total_score / weights_sum

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -147,7 +147,17 @@ class ProjectCreateView(LoginRequiredMixin, CreateView):
             }
 
             project = Project.objects.create(**project_data)
-            ProjectScore.objects.get_or_create(project=project)
+            
+            # Default all the score fields to 0 when a Project is created
+            ProjectScore.objects.get_or_create(
+                project=project,
+                core_mission_score=0,
+                operations_impact_score=0,
+                sustainability_score=0,
+                ease_score=0,
+                geographic_distance_score=0,
+                social_equity_score=0
+            )
 
             messages.success(self.request, 'Project successfully created.')
             return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project.pk}))

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -147,7 +147,7 @@ class ProjectCreateView(LoginRequiredMixin, CreateView):
             }
 
             project = Project.objects.create(**project_data)
-            
+
             # Default all the score fields to 0 when a Project is created
             ProjectScore.objects.get_or_create(
                 project=project,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,15 @@ def project(section_owner, project_category):
             project_info.update(kwargs)
 
             project = models.Project.objects.create(**project_info)
-            models.ProjectScore.objects.create(project=project)
+            models.ProjectScore.objects.create(
+                project=project,
+                core_mission_score=0,
+                operations_impact_score=0,
+                sustainability_score=0,
+                ease_score=0,
+                geographic_distance_score=0,
+                social_equity_score=0
+            )
             models.Phase.objects.create(
                 project=project,
                 phase_type='planning_feasibility',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,8 +12,8 @@ def test_project_score_total_method(project, score_weights):
     project = project.build()
     project_score_instance = project.projectscore
 
-    # at this point in the code, the ProjectScore fields have no data.
-    # so, test that total_score = 0 if there is a missing score
+    # When a project is created, all of the ProjectScore fields equal 0.
+    # So, test that total_score = 0.
     assert project_score_instance.total_score == 0
 
     updated_scores = {
@@ -27,6 +27,8 @@ def test_project_score_total_method(project, score_weights):
 
     project_score_instance.__dict__.update(updated_scores)
     project_score_instance.save()
+    
+    print('project_score_instance', project_score_instance)
 
     # calculate the score "by hand" (within this test)
     total_score = 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,8 +27,6 @@ def test_project_score_total_method(project, score_weights):
 
     project_score_instance.__dict__.update(updated_scores)
     project_score_instance.save()
-    
-    print('project_score_instance', project_score_instance)
 
     # calculate the score "by hand" (within this test)
     total_score = 0


### PR DESCRIPTION
## Overview

- Closes #208  

### Notes
This change:
- defaults all the project score fields when a project is created
- adds a signal to set `geographic_distance_score` and `social_equity_score` to 5 when the project is countywide


## Testing Instructions
- visit review app: https://ccfp-asset-d-patch-scor-fafe7c.herokuapp.com
- create a project
- change the scores
- confirm that the score changes even if there are no gis assets connected to the project

to test the countywide change:
- create a phase
- set the project as countywide
- confirm the score updates in the project detail view