### PR TITLE
Fix 500 error when copying assets between phases

### DIFF
--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -403,7 +403,7 @@ class ProjectScore(models.Model):
         if total_phase_geoms.area == 0.0:
             disinvested_proportion = 0
         else:
-            disinvested_areas = SocioEconomicZones.objects.get(displaygro='Both')
+            disinvested_areas = SocioEconomicZones.objects.filter(displaygro='Both').first()
 
             buffer = 0.00001
             phase_assets = LocalAsset.objects.filter(phase=instance.phase)


### PR DESCRIPTION
## Overview

We were getting a 500 error when copying/moving assets between phases, because duplicate assets were present in the data where we were expecting unique values. This branch makes a small change to use the `filter()` and `first()` methods instead of a `get()`, to account for those duplicates

Closes #222 

## Testing Instructions

* Within a project phase, check for pre-assigned assets or assign new assets.
* Using the dropdown towards the bottom of the page, copy/move those assets between one or more phases.
* Confirm that the page is redirected to the new phase, and that the assets got moved to that phase.
