### PR TITLE
Allow project search and sort by project manager

### DIFF
--- a/asset_dashboard/static/js/projectDataTable.js
+++ b/asset_dashboard/static/js/projectDataTable.js
@@ -31,11 +31,17 @@ $(document).ready(function() {
                 targets: [3]
             },
             {
+                name: 'project_manager',
+                orderable: true,
+                searchable: true,
+                targets: [4]
+            },
+            {
                 name: 'id',
                 orderable: false,
                 searchable: false,
                 visible: false,
-                targets: [4]
+                targets: [5]
             },
         ],
 

--- a/asset_dashboard/templates/asset_dashboard/projects.html
+++ b/asset_dashboard/templates/asset_dashboard/projects.html
@@ -25,7 +25,7 @@
 
           <!-- these elements filter the table, with the help of javascript -->
           <div class="row d-flex justify-content-around">
-              <input type="text" class="form-control col-lg-4 col-md-12 m-1" id="search-filter" placeholder="Search by Name or Description">
+              <input type="text" class="form-control col-lg-4 col-md-12 m-1" id="search-filter" placeholder="Search by Name, Description, or Project Manager">
 
               <select class="form-control col-lg-3 col-md-12 m-1" id="section-select">
                 <option value="" disabled selected >
@@ -55,7 +55,7 @@
                 </button>
               </div>
           </div>
-
+          
           <table class="table table-hover table-border py-4 dataTable no-footer" id="project-list-table">
             <thead>
               <tr>
@@ -63,6 +63,7 @@
                 <th>Description</th>
                 <th>Section</th>
                 <th>Category</th>
+                <th>Project Manager</th>
               </tr>
             </thead>
             <tbody>

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -111,8 +111,8 @@ class ProjectListView(LoginRequiredMixin, ListView):
 
 class ProjectListJson(LoginRequiredMixin, BaseDatatableView):
     model = Project
-    columns = ['name', 'description', 'section_owner', 'category', 'id']
-    order_columns = ['name', 'description', 'section_owner__name', 'category__name']
+    columns = ['name', 'description', 'section_owner', 'category', 'project_manager', 'id']
+    order_columns = ['name', 'description', 'section_owner__name', 'category__name', 'project_manager']
     max_display_length = 500
 
     def filter_queryset(self, qs):
@@ -121,7 +121,7 @@ class ProjectListJson(LoginRequiredMixin, BaseDatatableView):
         category = self.request.GET.get('columns[3][search][value]', None)
 
         if search:
-            qs = qs.filter(Q(name__icontains=search) | Q(description__icontains=search))
+            qs = qs.filter(Q(name__icontains=search) | Q(description__icontains=search) | Q(project_manager__icontains=search))
 
         if section:
             qs = qs.filter(section_owner__name=section)


### PR DESCRIPTION
## Overview

This adds the Project Manager column to the project listing table to allow users to more easily find projects by manager, or managers to find what projects they're managing.

Closes #214

### Demo
![pm-sort-example](https://github.com/fpdcc/ccfp-asset-dashboard/assets/114717958/32562a99-fa17-4dc0-9488-de77b5144839)

## Testing Instructions

* Create one or more projects with project managers
* Use the search to filter projects by manager
* Use the column's sort to order projects by manager
