### PR TITLE
Have table rows direct to project detail again, bug fix

### DIFF
--- a/asset_dashboard/static/js/projectDataTable.js
+++ b/asset_dashboard/static/js/projectDataTable.js
@@ -73,7 +73,7 @@ $(document).ready(function() {
         
         // make each row clickable for redirecting to the detail page
         fnRowCallback: function (row, data) {
-            const projectId = data[4]
+            const projectId = data[5]
 
             // add the id as an attribute to the <tr> element
             $(row).data('project-id', projectId)


### PR DESCRIPTION
## Overview

With pr #236 came a bug that made it so that clicking on a project row on the project listing page would **not** bring you to that project's detail page. This is a fix for that.

## Testing Instructions

* Confirm that clicking a project's row on the listing page brings you to that project's detail page
* Confirm that the users can still search and sort by project manager
