### PR TITLE
add delete project button

### DIFF
--- a/asset_dashboard/templates/asset_dashboard/partials/forms/edit_project_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/edit_project_form.html
@@ -146,4 +146,10 @@
           </div>
       </div>
   </form>
+  <div class="ml-auto">
+    <a class="mx-2 btn btn-outline-danger" id="delete-project" href="{% url 'delete-project'  pk=project.pk %}">
+      <i class='fas fa-trash'></i> 
+      Delete Project
+    </a>
+  </div>
 </section>

--- a/asset_dashboard/templates/asset_dashboard/project_confirm_delete.html
+++ b/asset_dashboard/templates/asset_dashboard/project_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends 'asset_dashboard/base.html' %}
+{% load static %}
+{% load static widget_tweaks i18n %}
+
+{% block title %}Delete Project{% endblock %}
+
+{% block body %}
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-5 bg-white p-3 border rounded shadow-sm">
+                <h2 class="text-center">Delete Project</h2>
+                <form method="POST">{% csrf_token %}
+                  <p class="text-center">Are you sure you want to delete <strong>{{ object }}</strong> project from the list of projects?</p>
+                  {{ form }}
+
+                  <div class="text-center m-2">
+                    <input type="submit" value="Confirm" class="btn btn-danger">
+                  </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    
+{% endblock %}

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -22,7 +22,7 @@ from asset_dashboard.endpoints import PortfolioViewSet, UserViewSet, \
     PortfolioPhaseViewSet, PhaseViewSet, ProjectViewSet, AssetViewSet, LocalAssetViewSet, \
     PromotePhaseView, CountywideView
 from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, \
-                                    ProjectUpdateView, ProjectListJson, \
+                                    ProjectUpdateView, ProjectListJson, ProjectDeleteView, \
                                     ProjectsByDistrictListView, ProjectsByDistrictListJson, \
                                     PhaseCreateView, PhaseUpdateView, \
                                     AssetAddEditView, FundingStreamCreateView, FundingStreamUpdateView, \
@@ -44,6 +44,7 @@ urlpatterns = [
     path('projects/json/', ProjectListJson.as_view(), name='project-list-json'),
     path('projects/add-project/', ProjectCreateView.as_view(), name='add-project'),
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
+    path('projects/delete/<int:pk>/', ProjectDeleteView.as_view(), name='delete-project'),
     path('projects/<int:pk>/phases/create/', PhaseCreateView.as_view(), name='create-phase'),
     path('projects/phases/edit/<int:pk>/', PhaseUpdateView.as_view(), name='edit-phase'),
     path('projects/phases/delete/<int:pk>/', PhaseDeleteView.as_view(), name='delete-phase'),

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -225,7 +225,6 @@ class ProjectDeleteView(LoginRequiredMixin, DeleteView):
     model = Project
 
     def get_success_url(self):
-        context = self.get_context_data()
         messages.success(self.request, 'Project successfully deleted.')
         return reverse('projects')
 

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -221,6 +221,15 @@ class ProjectUpdateView(LoginRequiredMixin, UpdateView):
         return super().form_valid(form)
 
 
+class ProjectDeleteView(LoginRequiredMixin, DeleteView):
+    model = Project
+
+    def get_success_url(self):
+        context = self.get_context_data()
+        messages.success(self.request, 'Project successfully deleted.')
+        return reverse('projects')
+
+
 class PhaseCreateView(LoginRequiredMixin, CreateView):
     template_name = 'asset_dashboard/partials/forms/add_edit_phase_form.html'
     form_class = PhaseForm


### PR DESCRIPTION
## Overview
This adds the ability to delete a project with a button towards the bottom of the attributes section of a project's detail page

Closes #218 

### Demo

<img width="1024" alt="image" src="https://github.com/fpdcc/ccfp-asset-dashboard/assets/114717958/7a707d02-470a-41ad-9e97-e3e1949d42c3">

### Notes
I have the button towards the bottom so it's out of the way of normal use but still reachable. If there's another spot that would make more sense, please lmk!

## Testing Instructions
* Create a dummy project to be deleted
* Go to that project's detail page, click the delete button, and confirm on the following page
* Confirm that:
  * you are redirected to the project listing page,
  * the project is no longer listed, and 
  * there is an appropriate success message at the top
