### PR TITLE
Add back button to delete confirmation pages

### DIFF
--- a/asset_dashboard/templates/asset_dashboard/fundingstream_confirm_delete.html
+++ b/asset_dashboard/templates/asset_dashboard/fundingstream_confirm_delete.html
@@ -15,6 +15,7 @@
 
                   <div class="text-center m-2">
                     <input type="submit" value="Confirm" class="btn btn-danger">
+                    <a href="/projects/phases/edit/{{funding_phase.pk}}" class="btn btn-outline-primary mt-md-2 mt-lg-0">Back to funding edit</a>
                   </div>
                 </form>
             </div>

--- a/asset_dashboard/templates/asset_dashboard/phase_confirm_delete.html
+++ b/asset_dashboard/templates/asset_dashboard/phase_confirm_delete.html
@@ -15,6 +15,7 @@
 
                   <div class="text-center m-2">
                     <input type="submit" value="Confirm" class="btn btn-danger">
+                    <a href="/projects/{{object.project.pk}}" class="btn btn-outline-primary mt-md-2 mt-lg-0">Back to project edit</a>
                   </div>
                 </form>
             </div>

--- a/asset_dashboard/templates/asset_dashboard/project_confirm_delete.html
+++ b/asset_dashboard/templates/asset_dashboard/project_confirm_delete.html
@@ -15,6 +15,7 @@
 
                   <div class="text-center m-2">
                     <input type="submit" value="Confirm" class="btn btn-danger">
+                    <a href="/projects/{{object.pk}}" class="btn btn-outline-primary mt-md-2 mt-lg-0">Back to project edit</a>
                   </div>
                 </form>
             </div>

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -318,10 +318,15 @@ class PhaseDeleteView(LoginRequiredMixin, DeleteView):
 class FundingStreamDeleteView(LoginRequiredMixin, DeleteView):
     model = FundingStream
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['funding_phase'] = context['object'].phase_set.get()
+        return context
+
     def get_success_url(self):
         context = self.get_context_data()
         messages.success(self.request, 'Funding Stream successfully deleted.')
-        return reverse('edit-phase', kwargs={'pk': context['fundingstream'].phase_set.get().id})
+        return reverse('edit-phase', kwargs={'pk': context['funding_phase'].id})
 
 
 class AssetAddEditView(LoginRequiredMixin, TemplateView):


### PR DESCRIPTION
## Overview

Add back buttons to delete pages based off where the delete button was located. Project and phase deletes go back to the project page, funding deletes go back the phase page.

Closes #245 

### Demo

<img width="425" alt="image" src="https://github.com/fpdcc/ccfp-asset-dashboard/assets/114717958/5925a572-c690-4c52-857f-b344d582d8d5">

## Testing Instructions
* Navigate to a delete page for a project, phase, or funding
* Confirm that the "back to <object> edit" button takes you back to the appropriate page
