### PR TITLE
Display error if there is no search query

### DIFF
--- a/asset_dashboard/static/js/components/maps/SelectAssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/SelectAssetsMap.js
@@ -121,6 +121,11 @@ function SelectAssetsMap(props) {
   function searchAssets() {
     setIsLoading(true)
 
+    if (searchText.length == 0) {
+      setAjaxMessage({text: 'Please enter a search query.', tag: 'danger'})
+      return
+    }
+
     const url = `/assets/?` + new URLSearchParams({
       'q': searchText,
       'asset_type': searchAssetType


### PR DESCRIPTION
## Overview

This requires input in the search field on asset creation/edit by displaying an error message if the user hasn't entered a query.

Closes #250

### Notes

A `require` attribute unfortunately didn't work on the `select` or the search `input` element. So instead, I went the route of having that little `if` statement

## Testing Instructions
* Navigate to a project's phase and click Edit Assets at the bottom
* Click the search button without entering a search term
  * Confirm that the search does not run and an error message is displayed
* Click the search button after entering a search term
  * Confirm that the search still works as normal
