### PR TITLE
Submit project form when navigating away from page

### DIFF
--- a/asset_dashboard/templates/asset_dashboard/project_detail.html
+++ b/asset_dashboard/templates/asset_dashboard/project_detail.html
@@ -40,6 +40,40 @@
       <script type="text/javascript">
         window.props = JSON.parse(document.getElementById('props').textContent)
         window.reactMount = document.getElementById('map')
+
+        const projectForm = document.getElementsByTagName('form')[0]
+        window.addEventListener('beforeunload', saveOnUnload)
+
+        function saveOnUnload(event) {
+          event.preventDefault()
+
+          let valid = projectForm.reportValidity()
+          if(!valid) {
+            event.returnValue = ""
+            // "Wait" zero time after the warning dialog so the forms errors display properly
+            setTimeout(() => {projectForm.reportValidity()}, 0)
+            return
+          }
+
+          let formDataObj = new FormData(projectForm)
+          fetch(`/projects/{{project.pk}}/`, {
+            method: 'POST',
+            body: formDataObj,
+            headers: {
+              'X-CSRFToken': getCookie('csrftoken'),
+            },
+            mode: 'same-origin'
+          })
+        }
+
+        const getCookie = (name) => {
+          const match = document.cookie.split(';').map(el => { let [key,value] = el.split('='); return { [key.trim()]: value }})
+          const filteredMatch = match.filter(e => Object.keys(e)[0] === name)
+
+          let matchLength = filteredMatch.length
+
+          return filteredMatch[matchLength - 1][name]
+        }
       </script>
       {% compress js %}
         <script type="text/jsx" src="{% static 'js/components/ProjectDetailAssetTable.js' %}"></script>


### PR DESCRIPTION
## Overview

This submits the project form when navigating away from the page, with the goal of not requiring users to click the Save Project button when editing. That includes going to a different page and closing the tab.

Closes #221

### Notes

The only use case that behaves strangely is saving when refreshing the page. It does run the validation and make the change server-side when refreshing, but does not reflect the change client-side when done. I tried to manipulate the method and the timing of fetch's redirect when refreshing, but that didn't work consistently.

I'm not sure how often folks would be refreshing the page after making a change, but if you have any ideas I'm absolutely open!

## Testing Instructions
* Navigate to a project detail page
* Edit some fields correctly and navigate away from the page
  * Return to the page to confirm that the new values have been saved
* Edit some fields incorrectly and navigate away from the page
  * Confirm that a warning about unsaved changes appears, and upon clicking cancel, form errors are displayed as if you had clicked the Save Project button
