### PR TITLE
Ensure the auto save and warning both work on firefox

### DIFF
--- a/asset_dashboard/templates/asset_dashboard/project_detail.html
+++ b/asset_dashboard/templates/asset_dashboard/project_detail.html
@@ -42,28 +42,30 @@
         window.reactMount = document.getElementById('map')
 
         const projectForm = document.getElementsByTagName('form')[0]
-        window.addEventListener('beforeunload', saveOnUnload)
+        window.addEventListener("visibilitychange", saveOnVisChange)
+        window.addEventListener('beforeunload', redirectDialog)
 
-        function saveOnUnload(event) {
-          event.preventDefault()
+        function saveOnVisChange(event) {
+          if (document.visibilityState === 'hidden') {
+            // Checking the validity here ensures that this doesn't get
+            // submitted if the user still chooses to leave the page with errors.
+            let valid = projectForm.reportValidity()
+            if(valid) {
+              let formDataObj = new FormData(projectForm)
+              navigator.sendBeacon(`/projects/{{project.pk}}/`, formDataObj)
+            }
+          }
+        }
 
+        function redirectDialog(event) {
           let valid = projectForm.reportValidity()
           if(!valid) {
+            event.preventDefault()
             event.returnValue = ""
-            // "Wait" zero time after the warning dialog so the forms errors display properly
+            // "Wait" zero time after the warning dialog so the form errors display properly
             setTimeout(() => {projectForm.reportValidity()}, 0)
             return
           }
-
-          let formDataObj = new FormData(projectForm)
-          fetch(`/projects/{{project.pk}}/`, {
-            method: 'POST',
-            body: formDataObj,
-            headers: {
-              'X-CSRFToken': getCookie('csrftoken'),
-            },
-            mode: 'same-origin'
-          })
         }
 
         const getCookie = (name) => {
@@ -71,7 +73,7 @@
           const filteredMatch = match.filter(e => Object.keys(e)[0] === name)
 
           let matchLength = filteredMatch.length
-
+ 
           return filteredMatch[matchLength - 1][name]
         }
       </script>


### PR DESCRIPTION
## Overview

The previous implementation of the auto save in #253 did not account for firefox's interpretation of `preventDefault` which always shows the warning message when navigating away, as opposed to only when errors were present. That presented issues with getting the page to wait for the form submission as well as a firefox's way of using `fetch`.

This fix uses [`navigator.sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) to submit the form, ensuring that the page does wait, and that it is successfully submitted.

Connects #221

## Testing Instructions

* Navigate to a project detail page on Firefox
* Edit some fields correctly and navigate away from the page
  * Return to the page to confirm that the new values have been saved
* Edit some fields incorrectly and navigate away from the page
  * Confirm that a warning about unsaved changes appears, and upon clicking cancel, form errors are displayed as if you had clicked the Save Project button
* Repeat above for Chrome
