### PR TITLE
Change language for shape buttons' tooltips

### DIFF
--- a/asset_dashboard/static/js/components/map_utils/EditControl.js
+++ b/asset_dashboard/static/js/components/map_utils/EditControl.js
@@ -147,4 +147,15 @@ EditControl.propTypes = {
   }),
 };
 
+// Change language for shape buttons' tooltips
+const drawBtns = leaflet.drawLocal.draw.toolbar.buttons
+const editBtns = leaflet.drawLocal.edit.toolbar.buttons
+
+for (var btn in drawBtns) {
+  drawBtns[btn] = drawBtns[btn].replace('Draw a', 'Select using')
+}
+for (var btn in editBtns) {
+  editBtns[btn] = editBtns[btn].replace('layers', 'selection')
+}
+
 export default EditControl;


### PR DESCRIPTION
## Overview

This changes the tooltip text in phase asset maps to use "select" and "selections" instead of "draw" and "layers".

Closes #259 

### Demo
![image](https://github.com/fpdcc/ccfp-asset-dashboard/assets/114717958/6b98bdf3-b0d9-48e7-b0e5-12b8a5d2bd58)

### Notes
This [answer in a github issue on react-leaflet-draw](https://github.com/alex3165/react-leaflet-draw/issues/55#issuecomment-434609919) was super useful in describing the structure of the `leaflet.drawLocal` attribute.

## Testing Instructions
* Navigate or create a phase and go to its asset edit page
* Enter a search term to make assets appear
* Confirm that the tooltip to the right of the map uses language like 
  * "Select using polygon" instead of "Draw a polygon"
  * "Clear selection" instead of "Clear layers"
