### PR TITLE
Format money inputs in USD

### DIFF
--- a/asset_dashboard/forms.py
+++ b/asset_dashboard/forms.py
@@ -87,6 +87,10 @@ class FundingStreamForm(StyledFormMixin, ModelForm):
     class Meta:
         model = FundingStream
         fields = ["budget", "year", "source_type", "funding_secured", "actual_cost"]
+        widgets = {
+            'budget': TextInput,
+            'actual_cost': TextInput,
+        }
 
 
 class PhaseForm(StyledFormMixin, ModelForm):

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -221,14 +221,14 @@
       for (i = 0; i < fundings.length; i++) {
         let funding = fundings[i]
         let year = funding[0].value
-        let budget = funding[1].value
-        let actual_cost = funding[3].value
+        let budget = funding[1].value.replaceAll(/\$|,/g, '')  // Remove all dollar signs and commas
+        let actual_cost = funding[2].value.replaceAll(/\$|,/g, '')
 
         const yearError = funding[0].nextElementSibling
-        const budgetError = funding[1].nextElementSibling.nextElementSibling
-        const costError = funding[3].nextElementSibling.nextElementSibling
-        const sourceError = funding[5].nextElementSibling
-        const securedError = funding[6].nextElementSibling
+        const budgetError = funding[1].nextElementSibling
+        const costError = funding[2].nextElementSibling
+        const sourceError = funding[3].nextElementSibling
+        const securedError = funding[4].nextElementSibling
 
         // Hide the errors that front end validation doesn't consider, 
         // in case they're visible from a previously failed attempt
@@ -243,17 +243,17 @@
           hideError(yearError)
         }
 
-        if (budget < 0){
+        if (budget.includes('.') || Number(budget) < 0 || isNaN(budget)){
           valid = false
-          budgetError.innerHTML = 'Please enter a valid amount'
+          budgetError.innerHTML = 'Please enter a valid whole dollar amount'
           showError(budgetError)
         } else {
           hideError(budgetError)
         }
 
-        if (actual_cost < 0){
+        if (actual_cost.includes('.') || Number(actual_cost) < 0 || isNaN(actual_cost)){
           valid = false
-          costError.innerHTML = 'Please enter a valid amount'
+          costError.innerHTML = 'Please enter a valid whole dollar amount'
           showError(costError)
         } else {
           hideError(costError)
@@ -268,10 +268,10 @@
         for (i = 0; i < fundings.length; i++) {
           let funding = fundings[i]
           const yearError = funding[0].nextElementSibling
-          const budgetError = funding[1].nextElementSibling.nextElementSibling
-          const costError = funding[3].nextElementSibling.nextElementSibling
-          const sourceError = funding[5].nextElementSibling
-          const securedError = funding[6].nextElementSibling
+          const budgetError = funding[1].nextElementSibling
+          const costError = funding[2].nextElementSibling
+          const sourceError = funding[3].nextElementSibling
+          const securedError = funding[4].nextElementSibling
 
           const errors = [yearError, budgetError, costError, sourceError, securedError]
           errors.forEach(error => {
@@ -282,10 +282,10 @@
 
           let data = {
             'year': funding[0].value,
-            'budget': funding[1].value,
-            'actual_cost': funding[3].value,
-            'source_type': funding[5].value,
-            'funding_secured': funding[6].value,
+            'budget': Number(funding[1].value.replaceAll(/\$|,/g, '')),
+            'actual_cost': Number(funding[2].value.replaceAll(/\$|,/g, '')),
+            'source_type': funding[3].value,
+            'funding_secured': funding[4].value,
             'phase': props.phase_id,
             'id': funding.id ? funding.id : null,
           }

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -201,6 +201,11 @@
       let removeBtn = newTd.getElementsByClassName('btn-outline-danger')[0]
       removeBtn.addEventListener('click', removeForm)
 
+      let newMoneyInputs = newTd.querySelectorAll('[name="budget"], [name="actual_cost"]')
+      newMoneyInputs.forEach((input)=>{
+        input.addEventListener('keyup', formatMoney)
+      })
+
       // Prevent previous unsaved inputs from being cleared when adding a new form
       newTr.appendChild(newTd)
       fundingTable.appendChild(newTr)
@@ -221,8 +226,8 @@
       for (i = 0; i < fundings.length; i++) {
         let funding = fundings[i]
         let year = funding[0].value
-        let budget = funding[1].value.replaceAll(/\$|,/g, '')  // Remove all dollar signs and commas
-        let actual_cost = funding[2].value.replaceAll(/\$|,/g, '')
+        let budget = unformatMoney(funding[1].value)
+        let actual_cost = unformatMoney(funding[2].value)
 
         const yearError = funding[0].nextElementSibling
         const budgetError = funding[1].nextElementSibling
@@ -282,8 +287,8 @@
 
           let data = {
             'year': funding[0].value,
-            'budget': Number(funding[1].value.replaceAll(/\$|,/g, '')),
-            'actual_cost': Number(funding[2].value.replaceAll(/\$|,/g, '')),
+            'budget': Number(unformatMoney(funding[1].value)),
+            'actual_cost': Number(unformatMoney(funding[2].value)),
             'source_type': funding[3].value,
             'funding_secured': funding[4].value,
             'phase': props.phase_id,
@@ -328,6 +333,30 @@
       }
     }
 
+    let moneyInputs = document.querySelectorAll('[name="budget"], [name="actual_cost"]')
+    moneyInputs.forEach((input)=>{
+      input.addEventListener('keyup', formatMoney)
+    })
+    function formatMoney(e) {
+      // Skip for arrow keys
+      if(e.keyCode >= 37 && e.keyCode <= 40){
+        return
+      }
+
+      let val = e.target.value
+      val = Number(unformatMoney(val))
+      // Only format if there is a value, to allow for empty boxes
+      if(val > 0){
+        val = val.toLocaleString()
+        e.target.value = '$' + val
+      }
+    }
+    
+    function unformatMoney(strValue) {
+      // Remove all dollar signs and commas
+      return strValue.replaceAll(/\$|,/g, '')
+    }
+
     const getCookie = (name) => {
         const match = document.cookie.split(';').map(el => { let [key,value] = el.split('='); return { [key.trim()]: value }})
         const filteredMatch = match.filter(e => Object.keys(e)[0] === name)
@@ -345,11 +374,11 @@
 
       for(i = 0; i < newFormsContainers.length; i++ ){
         let yearInput = newFormsContainers[i].querySelector('#id_year').value
-        let budgetInput = newFormsContainers[i].querySelector('#id_budget_0').value
-        let costInput = newFormsContainers[i].querySelector('#id_actual_cost_0').value
-        
-        if(yearInput || budgetInput > 0 || costInput > 0) {
-          // Ask user if they want to leave page, if there are unsaved funding inputs
+        let budgetInput = unformatMoney(newFormsContainers[i].querySelector('#id_budget').value)
+        let costInput = unformatMoney(newFormsContainers[i].querySelector('#id_actual_cost').value)
+
+        if(yearInput || Number(budgetInput) > 0 || Number(costInput) > 0) {
+          // Ask user if they want to leave page if there are unsaved, non-empty, positive inputs
           e.preventDefault();
           e.returnValue = ""
         }   

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -226,8 +226,8 @@
       for (i = 0; i < fundings.length; i++) {
         let funding = fundings[i]
         let year = funding[0].value
-        let budget = unformatMoney(funding[1].value)
-        let actual_cost = unformatMoney(funding[2].value)
+        let budget = moneyToNum(funding[1].value)
+        let actual_cost = moneyToNum(funding[2].value)
 
         const yearError = funding[0].nextElementSibling
         const budgetError = funding[1].nextElementSibling
@@ -248,7 +248,7 @@
           hideError(yearError)
         }
 
-        if (budget.includes('.') || Number(budget) < 0 || isNaN(budget)){
+        if (!Number.isInteger(budget) || budget < 0){
           valid = false
           budgetError.innerHTML = 'Please enter a valid whole dollar amount'
           showError(budgetError)
@@ -256,7 +256,7 @@
           hideError(budgetError)
         }
 
-        if (actual_cost.includes('.') || Number(actual_cost) < 0 || isNaN(actual_cost)){
+        if (!Number.isInteger(actual_cost) || actual_cost < 0){
           valid = false
           costError.innerHTML = 'Please enter a valid whole dollar amount'
           showError(costError)
@@ -287,8 +287,8 @@
 
           let data = {
             'year': funding[0].value,
-            'budget': Number(unformatMoney(funding[1].value)),
-            'actual_cost': Number(unformatMoney(funding[2].value)),
+            'budget': moneyToNum(funding[1].value),
+            'actual_cost': moneyToNum(funding[2].value),
             'source_type': funding[3].value,
             'funding_secured': funding[4].value,
             'phase': props.phase_id,
@@ -344,17 +344,24 @@
       }
 
       let val = e.target.value
-      val = Number(unformatMoney(val))
+      val = moneyToNum(val)
       // Only format if there is a value, to allow for empty boxes
       if(val > 0){
-        val = val.toLocaleString()
-        e.target.value = '$' + val
+        e.target.value = val.toLocaleString("en-US", {
+          style: "currency",
+          currency: "USD",
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        })
       }
     }
     
-    function unformatMoney(strValue) {
-      // Remove all dollar signs and commas
-      return strValue.replaceAll(/\$|,/g, '')
+    function moneyToNum(strValue) {
+      if (strValue == '' || strValue == '$') {
+        return null
+      }
+      // Remove all dollar signs and commas before converting
+      return Number(strValue.replaceAll(/\$|,/g, ''))
     }
 
     const getCookie = (name) => {
@@ -374,10 +381,10 @@
 
       for(i = 0; i < newFormsContainers.length; i++ ){
         let yearInput = newFormsContainers[i].querySelector('#id_year').value
-        let budgetInput = unformatMoney(newFormsContainers[i].querySelector('#id_budget').value)
-        let costInput = unformatMoney(newFormsContainers[i].querySelector('#id_actual_cost').value)
+        let budgetInput = moneyToNum(newFormsContainers[i].querySelector('#id_budget').value)
+        let costInput = moneyToNum(newFormsContainers[i].querySelector('#id_actual_cost').value)
 
-        if(yearInput || Number(budgetInput) > 0 || Number(costInput) > 0) {
+        if(yearInput || budgetInput > 0 || costInput > 0) {
           // Ask user if they want to leave page if there are unsaved, non-empty, positive inputs
           e.preventDefault();
           e.returnValue = ""

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -293,7 +293,7 @@ class PhaseUpdateView(LoginRequiredMixin, UpdateView):
                     })
                 }
             )
-        
+
         # Set the initial values to something more readable than the default: [Decimal('0'), 'USD']
         context['form'].funding_streams.base_fields['budget'].initial = '$0'
         context['form'].funding_streams.base_fields['actual_cost'].initial = '$0'

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -293,6 +293,10 @@ class PhaseUpdateView(LoginRequiredMixin, UpdateView):
                     })
                 }
             )
+        
+        # Set the initial values to something more readable than the default: [Decimal('0'), 'USD']
+        context['form'].funding_streams.base_fields['budget'].initial = '$0'
+        context['form'].funding_streams.base_fields['actual_cost'].initial = '$0'
 
         return context
 


### PR DESCRIPTION
## Overview

This formats the initial dollar amounts of pre-existing funding input fields to USD, with comma separators. This also applies the same formatting to those inputs as the user types.

Formatting while typing only applies when the amounts entered are numerical. And some extra validation was added now that those input fields allow for text instead of just numbers.

Closes #255

### Demo

![image](https://github.com/fpdcc/ccfp-asset-dashboard/assets/114717958/922aabdd-e280-4f5a-912a-793c2f53fa3c)

## Testing Instructions
* Create/navigate to a project phase
  * Create funding streams if needed
* Confirm that pre-existing funding streams have their amounts already formatted to USD with comma separators
* Edit pre-existing and new funding streams, particularly their funds and actual costs
* Confirm that formatting does get applied while typing
* Update the fundings to ensure that new inputs are actually saved
