### PR TITLE
Prevent planner table from resetting when selecting phases

### DIFF
--- a/asset_dashboard/static/js/components/BaseTable.js
+++ b/asset_dashboard/static/js/components/BaseTable.js
@@ -24,7 +24,7 @@ const BaseTable = ({ rows = [], columns, getTrProps = props => props, rowClassNa
     setPageSize,
     visibleColumns,
     state: { pageIndex, pageSize, expanded },
-  } = useTable({ columns, data, initialState: { pageIndex: 0, pageSize: sizeOfPage }}, useSortBy, useExpanded, usePagination)
+  } = useTable({ columns, data, autoResetSortBy: false, initialState: { pageIndex: 0, pageSize: sizeOfPage }}, useSortBy, useExpanded, usePagination)
 
   return (
     <div className="table-responsive">

--- a/asset_dashboard/static/js/components/BaseTable.js
+++ b/asset_dashboard/static/js/components/BaseTable.js
@@ -24,7 +24,7 @@ const BaseTable = ({ rows = [], columns, getTrProps = props => props, rowClassNa
     setPageSize,
     visibleColumns,
     state: { pageIndex, pageSize, expanded },
-  } = useTable({ columns, data, autoResetSortBy: false, initialState: { pageIndex: 0, pageSize: sizeOfPage }}, useSortBy, useExpanded, usePagination)
+  } = useTable({ columns, data, autoResetSortBy: false, autoResetPage: false, initialState: { pageIndex: 0, pageSize: sizeOfPage }}, useSortBy, useExpanded, usePagination)
 
   return (
     <div className="table-responsive">


### PR DESCRIPTION
## Overview

The cip planner's tables would reset the page and sorting every time a selection was made. This fix preserves both of those between selections.

Closes #258

### Demo
(Note: the tables here show 5 results per page, just so there are more pages to flip through for testing/demoing)
![image](https://user-images.githubusercontent.com/114717958/256564818-3e674896-d44f-46b5-8c6f-7b98e8ca657f.gif)

## Testing Instructions
* Navigate to the CIP planner
  * Make sure there are multiple pages worth of phases available for selection
* Make some selections on different pages while sorting on different columns
* Confirm that the sorting and the page number stay the same between selections
