### PR TITLE
Prevent preexisting assets from saving again

### DIFF
--- a/asset_dashboard/static/js/components/maps/SelectAssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/SelectAssetsMap.js
@@ -70,15 +70,33 @@ function SelectAssetsMap(props) {
   }
 
   function saveGeometries() {
-    const data = geomsToSave['features'].map(feature => {
-      return {
-        'asset_id': feature['properties']['identifier'],
-        'asset_type': searchAssetType,
-        'asset_name': feature['properties']['name'],
-        'geom': feature['geometry'],
-        'phase': phaseId
+    let existingIDs = []
+    existingGeoms.features.forEach(geom => {
+      existingIDs.push(geom.properties.asset_id)
+    })
+
+    let data = geomsToSave['features'].map(feature => {
+      // Only include feature if it doesn't already exist
+      if (!existingIDs.includes(feature.properties.identifier.toString())) {
+        return {
+          'asset_id': feature['properties']['identifier'],
+          'asset_type': searchAssetType,
+          'asset_name': feature['properties']['name'],
+          'geom': feature['geometry'],
+          'phase': phaseId
+        }
       }
-    }) 
+    })
+
+    // map() adds 'undefined' if the conditional fails, so filter those out
+    data = data.filter((item) => {
+      return item !== undefined
+    })
+
+    if (data.length == 0) {
+      setAjaxMessage({text: 'All selected assets already exist', tag: 'danger'})
+      return
+    }
     
     setIsSavingAssets(true)
 

--- a/asset_dashboard/static/js/components/maps/SelectAssetsMap.js
+++ b/asset_dashboard/static/js/components/maps/SelectAssetsMap.js
@@ -75,23 +75,22 @@ function SelectAssetsMap(props) {
       existingIDs.push(geom.properties.asset_id)
     })
 
-    let data = geomsToSave['features'].map(feature => {
-      // Only include feature if it doesn't already exist
-      if (!existingIDs.includes(feature.properties.identifier.toString())) {
-        return {
-          'asset_id': feature['properties']['identifier'],
-          'asset_type': searchAssetType,
-          'asset_name': feature['properties']['name'],
-          'geom': feature['geometry'],
-          'phase': phaseId
+    let data = geomsToSave['features']
+      .map(feature => {
+        // Only include feature if it doesn't already exist
+        if (!existingIDs.includes(feature.properties.identifier.toString())) {
+          return {
+            'asset_id': feature['properties']['identifier'],
+            'asset_type': searchAssetType,
+            'asset_name': feature['properties']['name'],
+            'geom': feature['geometry'],
+            'phase': phaseId
+          }
         }
-      }
-    })
-
-    // map() adds 'undefined' if the conditional fails, so filter those out
-    data = data.filter((item) => {
-      return item !== undefined
-    })
+      }).filter(feature => {
+        // map() adds 'undefined' if the conditional fails, so filter those out
+        return feature !== undefined
+      })
 
     if (data.length == 0) {
       setAjaxMessage({text: 'All selected assets already exist', tag: 'danger'})


### PR DESCRIPTION
## Overview
This branch fixes an asset duplication bug, so if a user:

 - selects only preexisting assets with the draw tool and saves, they will be presented with an error message at the top of the page and those assets will not be saved again.
 - selects a mix of preexisting and new assets, the preexisting ones will be excluded from the fetch command, allowing only the new assets to be saved.

Closes #266 

### Demo

![image](https://github.com/fpdcc/ccfp-asset-dashboard/assets/114717958/27500724-1a7c-491d-9c1d-25a92bd6cb3c)


## Testing Instructions
* Navigate to a project's phase and edit it's assets
* If needed, add a one or two assets
* Use the draw tool to select your previously added asset(s) along with some new ones
  * Confirm that only the new assets get saved, and the old ones are not duplicated
* Use the draw tool or the selector on the left to select only your previously added asset(s)
  * Confirm that nothing gets saved, the warning is displayed, and the page does not automatically reload
