### PR TITLE
Add phase filter, display readable labels for funding sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ FPDCC_DataMade_backup112221.tar/.blackbox/pubring.gpg~
 /.blackbox/secring.gpg
 /configs/.env.staging
 /configs/.env.production
+/static/compressor

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -82,6 +82,7 @@ class CipPlannerView(LoginRequiredMixin, TemplateView):
             'selectedPortfolio': selected_portfolio,
             'userId': self.request.user.id,
             'fundingSourceOptions': [{'value': type[0], 'label': type[1]} for type in FundingStream.SOURCE_TYPE_CHOICES],
+            'phaseOptions': [{'value': type[0], 'label': type[1]} for type in Phase.PHASE_TYPE_CHOICES]
         }
         return context
 


### PR DESCRIPTION
## Overview

This branch adds a phase filter to the CIP planner. It also changes the values in the table for funding sources to be a more readable label.

Because of that change, we're now ensuring that funding source (and phase) filtering happens based on the comparison between **label** in the table (i.e. Grants, Fees, & Other) and the **label** of the dropdown option (i.e. Grants, Fees, & Other), instead of the **label** in the table (i.e. Grants, Fees, & Other) and the **value** of the dropdown option (i.e. grants_fees_other).

- Connects #288 

### Demo

<img width="1407" alt="image" src="https://github.com/user-attachments/assets/b885127d-6cec-4b7a-829d-e48d53abeb5b" />

### Notes

This does not close the connected issue because there's going to be an extra step to select which filters users want to use dynamically. But I wanted to at first get a pattern in for phase filtering.

## Testing Instructions
* Head to the CIP planner
* Mess with the filters and confirm they work as expected
  * Pay special mind to the new phase filter and the funding source filter
