### PR TITLE
Rearrange csv fields, add recently created fields

### DIFF
--- a/asset_dashboard/static/js/PortfolioPlanner.js
+++ b/asset_dashboard/static/js/PortfolioPlanner.js
@@ -94,12 +94,15 @@ class PortfolioPlanner extends React.Component {
           funding_secured: funding['funding_secured'] ? 'Yes' : 'No',
           phase_year: project.phase_year,
           estimated_bid_quarter: project.estimated_bid_quarter,
-          status: project.status,
+          phase_status: project.phase_status,
+          project_status: project.project_status,
           project_manager: project.project_manager,
           countywide: project.countywide,
           assets: project.assets,
           project_id: project.project_id,
           phase_id: project.pk,
+          actual_cost: funding.actual_cost,
+          project_requester: project.project_requester,
         }
       })
     })
@@ -578,6 +581,9 @@ class PortfolioPlanner extends React.Component {
       })
 
       let row = {
+        'project_id': project.project_id,
+        'phase_id': project.phase_id,
+        'phase_funding_id': project.key,
         'name': project.name,
         funding_year: project.funding_year,
         funding_amount: parseFloat(project.funding_amount) || 0,
@@ -589,7 +595,10 @@ class PortfolioPlanner extends React.Component {
         'category': project.category,
         'project_manager': project.project_manager,
         'phase': project.phase,
-        'status': project.status,
+        'phase_status': project.phase_status,
+        'actual_cost': project.actual_cost,
+        'project_status': project.project_status,
+        'project_requester': project.project_requester,
         'description': project.description.replace(/\r\n/g, ' ').replace(/\n/g, ' ').replace(/\r/g, ' '),
         'notes': project.notes.replace(/\r\n/g, ' ').replace(/\n/g, ' ').replace(/\r/g, ' '),
         'score': project.score,
@@ -600,9 +609,6 @@ class PortfolioPlanner extends React.Component {
         'commissioner_districts': project.commissioner_districts.map(dist => dist.name).join(';'),
         ...assetsByType,
         ...costByZone,
-        'phase_funding_id': project.key,
-        'project_id': project.project_id,
-        'phase_id': project.phase_id
       }
 
       rows.push(row)

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -57,7 +57,7 @@ class CipPlannerView(LoginRequiredMixin, TemplateView):
                 'funding_streams': list(funding_streams.values()) if funding_streams else [],
                 'phase_year': phase.year,
                 'estimated_bid_quarter': phase.estimated_bid_quarter,
-                'status': phase.status,
+                'phase_status': phase.status,
                 'phase_type': phase.get_phase_type_display(),
                 'name': phase.project.name,
                 'description': phase.project.description,
@@ -74,6 +74,8 @@ class CipPlannerView(LoginRequiredMixin, TemplateView):
                 'commissioner_districts': list(phase.project.commissioner_districts.all().values('name')),
                 'assets': LocalAsset.group_assets_by_type(phase.localasset_set.all().values('asset_id', 'asset_model')),
                 'project_id': phase.project.id,
+                'project_status': phase.project.get_status_display(),
+                'project_requester': phase.project.get_requester_display(),
             })
 
         context['props'] = {


### PR DESCRIPTION
## Overview

The `project_ID`, `phase_id`, `phase_funding_id`, and `name` fields have been moved to the start of the csv, and a phase's `actual_cost`, `project_status`, and `project_requester` have been added.

- Closes #297

## Testing Instructions

* Pull down this branch and log in
  * Make sure you have one or more projects with phases, a status, and a requester
* Head to the CIP Planner and add projects to a portfolio
* Export the portfolio as a csv
* Confirm that the adjustments described above are present
* Confirm that all affected columns are populated as expected
