### PR TITLE
Autosave and warn on unsaved phase/funding edits

### DIFF
--- a/asset_dashboard/forms.py
+++ b/asset_dashboard/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, TextInput, ChoiceField, BooleanField
+from django.forms import ModelForm, TextInput, ChoiceField, BooleanField, NumberInput
 from .models import Project, FundingStream, ProjectScore, ProjectCategory, Phase
 
 
@@ -99,6 +99,9 @@ class PhaseForm(StyledFormMixin, ModelForm):
     class Meta:
         model = Phase
         fields = ["phase_type", "estimated_bid_quarter", "status", "year", "notes"]
+        widgets = {
+            'year': NumberInput(attrs={'min':1}),
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/asset_dashboard/static/css/app.css
+++ b/asset_dashboard/static/css/app.css
@@ -62,14 +62,33 @@ input[type="checkbox"] {
     width: 100%;
 }
 
-.input-loading {
-    background-color: rgba(255, 193, 7, .3) !important;
+.icon-loader, .icon-saved, .icon-failed {
+    display: inline-block;
 }
 
-.input-success {
-    background-color: rgba(40, 167, 70, .2) !important;
+.icon-loader {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #7e9137;
+    border-radius: 50%;
+    width: 25px;
+    height: 25px;
+    animation: spin 2s linear infinite;
 }
 
-.input-fail {
-    background-color: rgba(220, 53, 70, .2) !important;
+@-webkit-keyframes spin {
+    0% { -webkit-transform: rotate(0deg); }
+    100% { -webkit-transform: rotate(360deg); }
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+.fa-check-square {
+    color: #7e9137;
+}
+
+.fa-exclamation-circle {
+    color: #dc3545;
 }

--- a/asset_dashboard/static/css/app.css
+++ b/asset_dashboard/static/css/app.css
@@ -61,3 +61,15 @@ input[type="checkbox"] {
 .funding-table table {
     width: 100%;
 }
+
+.input-loading {
+    background-color: rgba(255, 193, 7, .3) !important;
+}
+
+.input-success {
+    background-color: rgba(40, 167, 70, .2) !important;
+}
+
+.input-fail {
+    background-color: rgba(220, 53, 70, .2) !important;
+}

--- a/asset_dashboard/static/js/components/PhaseDetailAssetTable.js
+++ b/asset_dashboard/static/js/components/PhaseDetailAssetTable.js
@@ -21,7 +21,7 @@ function PhaseDetailAssetTable(props) {
       <div className='row d-flex justify-content-between'>
         <div className="d-flex align-items-center justify-content-between m-2 col-4">
           <h3>Phase Assets</h3>
-          <a href={`/projects/phases/edit/${phaseId}/assets`} class="text-info lead" style={isCountywide ? {pointerEvents: "none", opacity: "0.4"} : {}}>Edit Assets ></a>
+          <a href={`/projects/phases/edit/${phaseId}/assets`} className="text-info lead" style={isCountywide ? {pointerEvents: "none", opacity: "0.4"} : {}}>Edit Assets ></a>
         </div>
         {
           isCountywide !== null 

--- a/asset_dashboard/static/js/components/helpers/CountywideForm.js
+++ b/asset_dashboard/static/js/components/helpers/CountywideForm.js
@@ -8,11 +8,18 @@ export default function CountywideForm({ currentCountywideValue, phaseId }) {
 
   function onCheckboxChange(event) {
     setIsCountywide(event.currentTarget.checked)
+    saveSelection(event.currentTarget.checked)
   }
   
-  function saveSelection() {
+  function saveSelection(manualVal) {
+    let countywideVal = isCountywide
+    if (manualVal === true || manualVal === false) {
+      // Only use manualVal if it's a true boolean
+      countywideVal = manualVal
+    }
+
     const api = new ApiService({ onResponse: setAjaxMessage })
-    api.saveCountywideSelection(isCountywide, phaseId)
+    api.saveCountywideSelection(countywideVal, phaseId)
   }
 
   return (

--- a/asset_dashboard/static/js/components/helpers/apiService.js
+++ b/asset_dashboard/static/js/components/helpers/apiService.js
@@ -74,7 +74,6 @@ class ApiService {
         method: 'POST',
         body: JSON.stringify(data)
     }).then((response) => {
-      console.log('response')
       if (response.status == 201) {
         this.onResponse({
           text: 'Countywide succesfully changed for phase.',

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -17,7 +17,20 @@
       {{ form.errors }}
 
       <div class="row col justify-content-between">
-        <h3>{% if phase %}Update Phase{% else %}Create Phase{% endif %}</h3>
+        <h3>
+          {% if phase %}
+            Update Phase
+            <div class="icon-loader phase-icon"></div>
+            <div class="icon-saved phase-icon">
+              <i class="fas fa-check-square" title="Saved" aria-label="Saved"></i>
+            </div>
+            <div class="icon-failed phase-icon">
+              <i class="fas fa-exclamation-circle" title="Save Failed" aria-label="Save Failed"></i>
+            </div>
+          {% else %}
+            Create Phase
+          {% endif %}
+        </h3>
         <button id="save-phase" class="btn btn-info">Save Phase</button>
       </div>
 
@@ -54,7 +67,18 @@
 <div class="row">
   <div class="col border border-secondary rounded shadow-sm p-3 m-2 card">
     <div class="d-flex justify-content-between m-3">
-      <h3>Phase Funding</h3>
+      <h3>
+        Phase Funding
+        {% if phase %}
+          <div class="icon-loader funding-icon"></div>
+          <div class="icon-saved funding-icon">
+            <i class="fas fa-check-square" title="Saved" aria-label="Saved"></i>
+          </div>
+          <div class="icon-failed funding-icon">
+            <i class="fas fa-exclamation-circle" title="Save Failed" aria-label="Save Failed"></i>
+          </div>
+        {% endif %}
+      </h3>
       {% if phase %}
         <button id="update-funding" class='btn btn-info'>Update Funding</button>
       {% endif %}
@@ -161,14 +185,14 @@
   <script type="text/javascript">
     window.props = JSON.parse(document.getElementById('props').textContent)
     window.reactMount = document.getElementById('map')
-    let hasUnsavedChanges = false
-    let delayTimer
-
     // Don't worry about auto-saving or funding stream forms if it's a new phase
     if (!`{{ phase }}`) {
       throw new Error("This is a new phase and will need to be saved manually")
     }
 
+    $(".icon-loader, .icon-failed").hide()
+
+    let delayTimer
     function trackChanges() {
       // All visible inputs will keep track of whether any changes have been made
       const allInputs = $(":input:not(.btn.btn-info, :hidden)")
@@ -179,10 +203,8 @@
         }
 
         clearTimeout(delayTimer)
-        hasUnsavedChanges = true
-        // TODO: don't do the success/loading classes. instead, let's display save status somewhere in each box
-        e.target.classList.add("input-loading")
-        e.target.classList.remove("input-success", "input-fail")
+        $(".icon-loader").show()
+        $(".icon-saved, .icon-failed").hide()
         delayTimer = setTimeout(() => {
           submitForms(e)
         }, 500)
@@ -362,14 +384,23 @@
           )
         }
 
-        // Wait until all fetches run, then either show serverError or reload page
+        // Wait until all fetches run, then show errors if appropriate
         Promise.all(fetches).then(function() {
+          $(".icon-loader.funding-icon").hide()
+
           if (!backendValid) {
             showError(serverError)
+            $(".icon-failed.funding-icon").show()
+            $(".icon-saved.funding-icon").hide()
           } else {
             hideError(serverError)
+            $(".icon-saved.funding-icon").show()
+            $(".icon-failed.funding-icon").hide()
           }
         })
+      } else {
+        $(".icon-loader.funding-icon, .icon-saved.funding-icon").hide()
+        $(".icon-failed.funding-icon").show()
       }
     }
 
@@ -451,28 +482,18 @@
     }
 
     function submitForms(e) {
+      submitFundingForms()
+
       const phaseSucceeded = phaseForm.reportValidity()
-
+      $(".icon-loader.phase-icon").hide()
       if (phaseSucceeded) {
-        console.log("submitting...")
-        submitFundingForms()
-
         const formDataObj = new FormData(phaseForm)
         navigator.sendBeacon(`/projects/phases/edit/${window.props.phase_id}/`, formDataObj)
-        console.log("form sent")
-        hasUnsavedChanges = false
-
-        if (e.target.classList.contains("form-control")) {
-          e.target.classList.add("input-success")
-          e.target.classList.remove("input-loading", "input-fail")
-        }
-
-        console.log("done!")
+        $(".icon-saved.phase-icon").show()
+        $(".icon-failed.phase-icon").hide()
       } else {
-        if (e.target.classList.contains("form-control")) {
-          e.target.classList.add("input-fail")
-          e.target.classList.remove("input-success", "input-loading")
-        }
+        $(".icon-failed.phase-icon").show()
+        $(".icon-saved.phase-icon").hide()
       }
     }
   </script>

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -496,6 +496,14 @@
         $(".icon-saved.phase-icon").hide()
       }
     }
+
+    window.addEventListener('beforeunload', (e) => {
+      // Warn the user of unsaved changes if there are errors on the page
+      if ($(".icon-failed").is(":visible")) {
+        e.preventDefault()
+        e.returnValue = ""
+      }
+    })
   </script>
   {% compress js %}
     <script type="text/jsx" src="{% static 'js/components/PhaseDetailAssetTable.js' %}"></script>

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -194,7 +194,7 @@
 
     let delayTimer
     function trackChanges() {
-      // All visible inputs will keep track of whether any changes have been made
+      // All visible inputs will trigger a save if any they detect any changes
       const allInputs = $(":input:not(.btn.btn-info, :hidden)")
       allInputs.on("change keyup", function(e) {
         // Ignore left and right arrow key inputs

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -11,14 +11,14 @@
 <div class="row">
   <div class="border border-secondary rounded shadow-sm col m-2 p-3 card">
 
-    <form method="post">
+    <form method="post" id="phaseForm" name="phaseForm">
       {% csrf_token %}
 
       {{ form.errors }}
-  
+
       <div class="row col justify-content-between">
         <h3>{% if phase %}Update Phase{% else %}Create Phase{% endif %}</h3>
-        <input type="submit" value="Save Phase" class="btn btn-info">
+        <button id="save-phase" class="btn btn-info">Save Phase</button>
       </div>
 
       <div class="row my-4">
@@ -56,7 +56,7 @@
     <div class="d-flex justify-content-between m-3">
       <h3>Phase Funding</h3>
       {% if phase %}
-        <btn id="update-funding" class='btn btn-info'>Update Funding</btn>
+        <button id="update-funding" class='btn btn-info'>Update Funding</button>
       {% endif %}
     </div>
     {% if not phase %}
@@ -103,7 +103,6 @@
                       {{ form.funding.funding_secured }}
                       <div class="secured-error" aria-hidden="true"></div>
                     </td>
-                    <td class="pl-2 d-none" aria-hidden="true">{{ form.id.as_hidden }}</td>
                     <td><a href="{% url 'delete-funding' pk=form.id %}" class='btn btn-sm btn-outline-danger'><i class='fas fa-trash'></i> Delete</a>
                   </tbody>
                 </table>
@@ -162,6 +161,40 @@
   <script type="text/javascript">
     window.props = JSON.parse(document.getElementById('props').textContent)
     window.reactMount = document.getElementById('map')
+    let hasUnsavedChanges = false
+    let delayTimer
+
+    // Don't worry about auto-saving or funding stream forms if it's a new phase
+    if (!`{{ phase }}`) {
+      throw new Error("This is a new phase and will need to be saved manually")
+    }
+
+    function trackChanges() {
+      // All visible inputs will keep track of whether any changes have been made
+      const allInputs = $(":input:not(.btn.btn-info, :hidden)")
+      allInputs.on("change keyup", function(e) {
+        // Ignore left and right arrow key inputs
+        if (e.keyCode == 37 || e.keyCode == 39){
+          return
+        }
+
+        clearTimeout(delayTimer)
+        hasUnsavedChanges = true
+        // TODO: don't do the success/loading classes. instead, let's display save status somewhere in each box
+        e.target.classList.add("input-loading")
+        e.target.classList.remove("input-success", "input-fail")
+        delayTimer = setTimeout(() => {
+          submitForms(e)
+        }, 500)
+      })
+    }
+    window.addEventListener("load", (event) => {
+      trackChanges()
+    })
+
+    const phaseForm = document.forms.phaseForm
+    const phaseSubmitBtn = document.getElementById("save-phase")
+    phaseSubmitBtn.addEventListener('click', submitForms)
 
     let addSourceBtn = document.getElementById('add-source')
     addSourceBtn.addEventListener('click', addSource)
@@ -217,6 +250,7 @@
       // Prevent previous unsaved inputs from being cleared when adding a new form
       newTr.appendChild(newTd)
       fundingTable.appendChild(newTr)
+      trackChanges()
     }
 
     function removeForm() {
@@ -224,13 +258,13 @@
     }
 
     let updateFundingBtn = document.getElementById('update-funding')
-    updateFundingBtn.addEventListener('click', submitFundingForms)
+    updateFundingBtn.addEventListener('click', submitForms)
     function submitFundingForms() {
       fundings = document.getElementsByClassName("funding")
       serverError = document.getElementById("server-error")
       let valid = true
 
-      // Front end validation for each form on the page
+      // Front end validation for each funding form on the page
       for (i = 0; i < fundings.length; i++) {
         let funding = fundings[i]
         let year = funding[0].value
@@ -247,7 +281,7 @@
         // in case they're visible from a previously failed attempt
         hideError(sourceError)
         hideError(securedError)
-        
+
         if (year.toString().length != 4 || !year){
           valid = false
           yearError.innerHTML = 'Please enter a valid year'
@@ -334,10 +368,8 @@
             showError(serverError)
           } else {
             hideError(serverError)
-            window.removeEventListener('beforeunload', redirectDialog)
-            location.reload()
           }
-        })    
+        })
       }
     }
 
@@ -363,7 +395,7 @@
         })
       }
     }
-    
+
     function moneyToNum(strValue) {
       if (strValue == '' || strValue == '$') {
         return null
@@ -379,25 +411,6 @@
         let matchLength = filteredMatch.length
 
         return filteredMatch[matchLength - 1][name]
-    }
-
-    window.addEventListener('beforeunload', redirectDialog)
-
-    function redirectDialog(e){
-      let hasUnsavedForms = false
-      let newFormsContainers = document.getElementsByClassName('new-tr')
-
-      for(i = 0; i < newFormsContainers.length; i++ ){
-        let yearInput = newFormsContainers[i].querySelector('#id_year').value
-        let budgetInput = moneyToNum(newFormsContainers[i].querySelector('#id_budget').value)
-        let costInput = moneyToNum(newFormsContainers[i].querySelector('#id_actual_cost').value)
-
-        if(yearInput || budgetInput > 0 || costInput > 0) {
-          // Ask user if they want to leave page if there are unsaved, non-empty, positive inputs
-          e.preventDefault();
-          e.returnValue = ""
-        }   
-      }
     }
 
     function showBackendErrors(data, yearError, budgetError, costError, sourceError, securedError) {
@@ -435,6 +448,32 @@
     function hideError(error){
       error.classList.remove("visible")
       error.setAttribute("aria-hidden","true")
+    }
+
+    function submitForms(e) {
+      const phaseSucceeded = phaseForm.reportValidity()
+
+      if (phaseSucceeded) {
+        console.log("submitting...")
+        submitFundingForms()
+
+        const formDataObj = new FormData(phaseForm)
+        navigator.sendBeacon(`/projects/phases/edit/${window.props.phase_id}/`, formDataObj)
+        console.log("form sent")
+        hasUnsavedChanges = false
+
+        if (e.target.classList.contains("form-control")) {
+          e.target.classList.add("input-success")
+          e.target.classList.remove("input-loading", "input-fail")
+        }
+
+        console.log("done!")
+      } else {
+        if (e.target.classList.contains("form-control")) {
+          e.target.classList.add("input-fail")
+          e.target.classList.remove("input-success", "input-loading")
+        }
+      }
     }
   </script>
   {% compress js %}


### PR DESCRIPTION
## Overview

This branch autosaves phase and funding stream details whenever a change happens in one of the inputs. It also extends the warning that was already in place for unsaved funding streams, to also apply to phase details.

- Connects #276 

### Demo

![image](https://github.com/user-attachments/assets/e9f1da8d-8dfa-4e2c-9e13-e94c3a6ec6cf)

## Testing Instructions

* Pull down this branch, log in, and head to a created project
  * If needed, add a new phase and/or funding streams to a phase
* Edit the phase details and funding stream details
  * Confirm any changes to either section causes the page to save changes on both
  * Confirm that they get saved by refreshing the page, or viewing the detail of the phase from the project view
  * Confirm that their save statuses, indicated by the icon to the right of the header for each card, get updated independently
* Trigger an error in one of the forms. You can, for example, insert an `e` into one of the year inputs
  * Confirm that the error icon appears just for the section that has an error
  * Try navigating away without fixing the error and confirm that a warning displays
* Click the "set phase as countywide" checkbox towards the bottom
  * Confirm that a success message shows and the page reloads to show the grayed out phase assets section as expected.
* Try to add a new phase
  * Confirm that none of the icons, auto saving, or warnings happen when creating a new phase from scratch