### PR TITLE
Fix app making multiple fundings for each new one made

### DIFF
--- a/asset_dashboard/serializers.py
+++ b/asset_dashboard/serializers.py
@@ -345,4 +345,8 @@ class FundingStreamSerializer(serializers.Serializer):
         )
         phase.funding_streams.add(funding_stream)
 
+        # Give the front end access to a new funding's id
+        if created:
+            data["id"] = funding_stream.id
+
         return data

--- a/asset_dashboard/settings.py
+++ b/asset_dashboard/settings.py
@@ -44,6 +44,20 @@ if os.getenv('SENTRY_DSN'):
         integrations=[DjangoIntegration()],
     )
 
+if DEBUG:
+    import socket
+
+    # Add dynamically generated Docker IP
+    # Don't do this in production!
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    INTERNAL_IPS = [ip[:-1] + "1" for ip in ips] + ["127.0.0.1"]
+
+# Django Debug Toolbar Panel Settings
+DEBUG_TOOLBAR_PANELS = [
+    "debug_toolbar.panels.sql.SQLPanel",
+    "debug_toolbar.panels.cache.CachePanel",
+]
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -60,10 +74,12 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework_gis',
     'django.contrib.humanize',
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -220,4 +236,3 @@ GEOM_BUFFER = .000005
 
 # remove decimal places for djmoney
 CURRENCY_DECIMAL_PLACES = 0
-

--- a/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/forms/add_edit_phase_form.html
@@ -127,7 +127,11 @@
                       {{ form.funding.funding_secured }}
                       <div class="secured-error" aria-hidden="true"></div>
                     </td>
-                    <td><a href="{% url 'delete-funding' pk=form.id %}" class='btn btn-sm btn-outline-danger'><i class='fas fa-trash'></i> Delete</a>
+                    <td>
+                      <a href="{% url 'delete-funding' pk=form.id %}" class='btn btn-sm btn-outline-danger'>
+                        <i class='fas fa-trash'></i> Delete
+                      </a>
+                    </td>
                   </tbody>
                 </table>
               </form>
@@ -370,7 +374,7 @@
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
               },
-              mode: 'same-origin' 
+              mode: 'same-origin'
             }).then((response)=> {
               if (response.status != 201) {
                 backendValid = false
@@ -379,6 +383,17 @@
             }).then(data => {
               if (!backendValid) {
                 showBackendErrors(data, ...errors)
+              } else if (!funding.id) {
+                // Associate this new form with its new funding stream
+                funding.id = data["id"]
+
+                // Make the remove button, a delete button
+                const removeTd = funding.querySelector('td:last-child')
+                const deleteBtnFragment = `
+                <a href="/projects/phases/${data["id"]}/funding/delete/" class='btn btn-sm btn-outline-danger'>
+                  <i class='fas fa-trash'></i> Delete
+                </a>`
+                removeTd.innerHTML = deleteBtnFragment
               }
             })
           )

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -13,6 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf import settings
+from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth import views as auth_views
@@ -64,3 +66,8 @@ urlpatterns = [
 
 handler404 = 'asset_dashboard.views.page_not_found'
 handler500 = 'asset_dashboard.views.server_error'
+
+if settings.DEBUG:
+    import debug_toolbar
+
+    urlpatterns += [url(r"^__debug__/", include(debug_toolbar.urls))]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-datatables-view==1.19.1
 django-widget-tweaks==1.4.8
 djangorestframework==3.13.1
 djangorestframework-gis==0.18
+django-debug-toolbar>=3.4,<3.5
 tqdm==4.67.1
 
 # Testing requirements


### PR DESCRIPTION
## Overview

This branch stops the app from creating multiple identical funding streams any time a **new** one is made. It does this by giving the added form the pk of the newly made funding stream after creation. In my first iteration of this (#303) I only tested existing funding streams and missed this intricacy.

- Closes #306

### Notes

I also added django debug toolbar into the app in this branch that'll only run when debug is `True` so that I could investigate why refreshing the phase edit page took so long, but the sql query times that the toolbar reported seemed pretty short. I can look more into that more another time.

## Testing Instructions

* Build the container so that the debug toolbar gets installed into your instance, then bring it up
* Head to a project phase, or create one if necessary
* Add one or more new phase funding stream(s)
  * Confirm that the save icon at the top of the funding section accurately shows that it has been saved
  * Confirm that the "Remove" button on the funding has been relabeled as "Delete" after saved, and works as expected
  * Refresh the phase edit page and confirm that there is only one copy of the funding stream you've made
  * Confirm that editing an existing funding stream still works as expected
* Confirm that the django debug toolbar works as expected 
